### PR TITLE
Add Tree View

### DIFF
--- a/Sources/Views/MenuBarView.swift
+++ b/Sources/Views/MenuBarView.swift
@@ -1,4 +1,16 @@
-import SwiftUI
+import SwiftUI 
+
+// MARK: - Process Group
+
+struct ProcessGroup: Identifiable {
+	let id: Int // Use PID as stable identifier
+	let processName: String
+	let ports: [PortInfo]
+	
+	var displayName: String {
+		"\(processName) (\(ports.count) port\(ports.count == 1 ? "" : "s"))"
+	}
+}
 
 struct MenuBarView: View {
     @Environment(\.openWindow) private var openWindow
@@ -7,7 +19,20 @@ struct MenuBarView: View {
     @State private var confirmingKillAll = false
     @State private var confirmingKillPort: UUID?
     @State private var hoveredPort: UUID?
-
+	@State private var expandedProcesses: Set<Int> = []
+	@State private var useTreeView = UserDefaults.standard.bool(forKey: "useTreeView")
+	
+	private var groupedByProcess: [ProcessGroup] {
+		let grouped = Dictionary(grouping: filteredPorts) { $0.pid }
+		return grouped.map { pid, ports in
+			ProcessGroup(
+				id: pid,
+				processName: ports.first?.processName ?? "Unknown",
+				ports: ports.sorted { $0.port < $1.port }
+			)
+		}.sorted { $0.processName.localizedCaseInsensitiveCompare($1.processName) == .orderedAscending }
+	}
+	
     private var filteredPorts: [PortInfo] {
         let filtered = searchText.isEmpty ? state.ports : state.ports.filter {
             String($0.port).contains(searchText) || $0.processName.localizedCaseInsensitiveContains(searchText)
@@ -61,20 +86,38 @@ struct MenuBarView: View {
             // Port List
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    if filteredPorts.isEmpty {
-                        VStack(spacing: 8) {
-                            Image(systemName: "checkmark.circle")
-                                .font(.largeTitle)
-                                .foregroundStyle(.green)
-                            Text("No open ports")
-                                .foregroundStyle(.secondary)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 40)
-                    } else {
+					if filteredPorts.isEmpty {
+						VStack(spacing: 8) {
+							Image(systemName: "checkmark.circle")
+								.font(.largeTitle)
+								.foregroundStyle(.green)
+							Text("No open ports")
+								.foregroundStyle(.secondary)
+						}
+						.frame(maxWidth: .infinity)
+						.padding(.vertical, 40)
+					} else if useTreeView {
+							ForEach(groupedByProcess) { group in
+								ProcessGroupRow(
+									group: group,
+									isExpanded: expandedProcesses.contains(group.id),
+									onToggleExpand: {
+										if expandedProcesses.contains(group.id) {
+											expandedProcesses.remove(group.id)
+										} else {
+											expandedProcesses.insert(group.id)
+										}
+									},
+									onKillProcess: {
+										for port in group.ports {
+											Task { await state.killPort(port) }
+										}
+									}
+								)
+							}
+					} else {
                         ForEach(filteredPorts) { port in
-                            PortRow(port: port, state: state, isHovered: hoveredPort == port.id, confirmingKill: $confirmingKillPort)
-                                .onHover { hoveredPort = $0 ? port.id : nil }
+                            PortRow(port: port, state: state, confirmingKill: $confirmingKillPort)
                         }
                     }
                 }
@@ -134,6 +177,18 @@ struct MenuBarView: View {
                 .buttonStyle(.plain)
                 .help("Quit")
                 .keyboardShortcut("q", modifiers: .command)
+				
+				// View toggle button
+				Button {
+					useTreeView.toggle()
+					UserDefaults.standard.set(useTreeView, forKey: "useTreeView")
+				} label: {
+					Image(systemName: useTreeView ? "list.bullet" : "list.bullet.indent")
+				}
+				.buttonStyle(.plain)
+				.help(useTreeView ? "Show list view" : "Show tree view")
+				.keyboardShortcut("t", modifiers: .command)
+				
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
@@ -142,13 +197,138 @@ struct MenuBarView: View {
     }
 }
 
-// MARK: - Port Row
+// MARK: - Process Group Row
+
+struct ProcessGroupRow: View {
+	let group: ProcessGroup
+	let isExpanded: Bool
+	let onToggleExpand: () -> Void
+	let onKillProcess: () -> Void
+	
+	@State private var showConfirm = false
+	@State private var isHovered = false
+	@State private var isKilling = false
+	
+	var body: some View {
+		VStack(spacing: 0) {
+			// Process header
+			HStack(spacing: 10) {
+				// Expand/collapse indicator
+				Button(action: onToggleExpand) {
+					Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				}
+				.buttonStyle(.plain)
+				
+				// Status indicator
+				Circle()
+					.fill(isKilling ? .orange : .green)
+					.frame(width: 6, height: 6)
+					.shadow(color: (isKilling ? Color.orange : Color.green).opacity(0.5), radius: 3)
+					.opacity(isKilling ? 0.3 : 1)
+					.animation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true), value: isKilling)
+				
+				// Process name with port count
+				Text(group.displayName)
+					.font(.callout)
+					.fontWeight(.medium)
+				
+				Spacer()
+				
+				// PID
+				Text("PID \(group.id)")
+					.font(.caption2)
+					.foregroundStyle(.secondary)
+				
+				// Kill process button (visible on hover)
+				if showConfirm {
+					HStack(spacing: 4) {
+						Button {
+							showConfirm = false
+							isKilling = true
+							onKillProcess()
+						} label: {
+							Image(systemName: "checkmark.circle.fill")
+								.foregroundStyle(.green)
+						}
+						.buttonStyle(.plain)
+						
+						Button {
+							showConfirm = false
+						} label: {
+							Image(systemName: "xmark.circle.fill")
+								.foregroundStyle(.secondary)
+						}
+						.buttonStyle(.plain)
+					}
+				} else {
+					Button {
+						showConfirm = true
+					} label: {
+						Image(systemName: "xmark.circle.fill")
+							.foregroundStyle(.red)
+					}
+					.buttonStyle(.plain)
+					.opacity(isHovered ? 1 : 0)
+				}
+			}
+			.padding(.horizontal, 12)
+			.padding(.vertical, 8)
+			.background(isHovered ? Color.primary.opacity(0.05) : Color.clear)
+			.contentShape(Rectangle())
+			.onHover { hovering in
+				isHovered = hovering
+			}
+			
+			// Expanded ports
+			if isExpanded {
+				ForEach(group.ports) { port in
+					NestedPortRow(port: port)
+				}
+			}
+		}
+	}
+}
+
+// MARK: - Nested Port Row
+
+struct NestedPortRow: View {
+	let port: PortInfo
+	
+	var body: some View {
+		HStack(spacing: 10) {
+			// Indent for nesting
+			Rectangle()
+				.fill(.clear)
+				.frame(width: 32)
+			
+			// Port number
+			Text(port.displayPort)
+				.font(.system(.callout, design: .monospaced))
+				.frame(width: 60, alignment: .leading)
+			
+			// Address and protocol
+			Text("\(port.address) • \(port.displayPort)")
+				.font(.caption)
+				.foregroundStyle(.secondary)
+			
+			Spacer()
+		}
+		.padding(.horizontal, 12)
+		.padding(.vertical, 6)
+		.contentShape(Rectangle())
+	}
+}
+
+// MARK: - List View Port Row
+
 struct PortRow: View {
     let port: PortInfo
     @Bindable var state: AppState
-    let isHovered: Bool
     @Binding var confirmingKill: UUID?
     @State private var isKilling = false
+	@State private var isHovered = false
 
     private var isConfirming: Bool { confirmingKill == port.id }
 
@@ -224,6 +404,9 @@ struct PortRow: View {
         .padding(.vertical, 8)
         .background((isHovered || isConfirming) ? Color.primary.opacity(0.05) : Color.clear)
         .contentShape(Rectangle())
+		.onHover { hovering in
+			isHovered = hovering
+		}
         .contextMenu {
             Button { state.toggleFavorite(port.port) } label: {
                 Label(state.isFavorite(port.port) ? "Remove from Favorites" : "Add to Favorites",


### PR DESCRIPTION
Needed a small refactor in the logic + addition of a button (and userDefault to track the change)
Since you can't kill ports, but processes liked to the port, now we reason thinking of processes. Also added a small button to switch between the two view types (can be improved)

Please note that to speed up the addition of the feature  there was use of AI Agents, but i manually checked every line to make sure the choices made were reasonable, and guided the agent towards a cleaner solution.

Please let me know if you'd like some revisions

This would solve Issue #5 