### PR TITLE
fix: adjust padding for port status indicator alignment

### DIFF
--- a/Sources/Views/PortTableView.swift
+++ b/Sources/Views/PortTableView.swift
@@ -59,7 +59,8 @@ struct PortTableView: View {
                 .foregroundStyle(.secondary)
                 .frame(width: 80)
         }
-        .padding(.horizontal, 16)
+        .padding(.leading, 24)
+        .padding(.trailing, 16)
         .padding(.vertical, 8)
         .background(Color(nsColor: .controlBackgroundColor))
     }
@@ -251,7 +252,8 @@ struct PortListRow: View {
             }
             .frame(width: 100)
         }
-        .padding(.horizontal, 16)
+        .padding(.leading, 24)
+        .padding(.trailing, 16)
         .padding(.vertical, 8)
         .background(isHovered ? Color.primary.opacity(0.05) : Color.clear)
         .onHover { hovering in


### PR DESCRIPTION
## Summary

This PR fixes a minor UI issue where the port status indicator was visually misaligned within the ports table.

## Changes

- Adjusted padding to properly align the port status indicator.
- No functional or behavioral changes were introduced.
- The fix is purely visual and scoped to the affected table row layout.

## Testing

- Built and ran the app locally.
- Verified that the status indicator is correctly aligned across table rows.
- Confirmed no regressions in the ports table UI.

## Notes

This is a small, focused UI improvement intended to enhance visual consistency and readability.