### PR TITLE
fix: update runner to macos-latest in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
     name: Build and Release
-    runs-on: macos-14  # Apple Silicon runner
+    runs-on: macos-latest  # Apple Silicon runner
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This should still work for older macOS versions, but users of Tahoe will now have the latest Liquid Glass UI.