### PR TITLE
feat: add process familiarity filtering and recent appearance sorting

### DIFF
--- a/Sources/AppState+PortOperations.swift
+++ b/Sources/AppState+PortOperations.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Defaults
 
 extension AppState {
     /// Refreshes the port list by scanning for active ports.
@@ -18,12 +19,52 @@ extension AppState {
         let oldSet = Set(ports.map { "\($0.port)-\($0.pid)" })
         guard newSet != oldSet else { return }
 
+        updateProcessFamiliarityStats(newPorts: newPorts)
+        
         ports = newPorts.sorted { a, b in
             let aFav = favorites.contains(a.port)
             let bFav = favorites.contains(b.port)
             if aFav != bFav { return aFav }
             return a.port < b.port
         }
+    }
+    
+    private func updateProcessFamiliarityStats(newPorts: [PortInfo]) {
+        let now = Date()
+        let deltaSeconds: TimeInterval
+        
+        if let lastTime = lastRefreshTime {
+            deltaSeconds = now.timeIntervalSince(lastTime)
+        } else {
+            deltaSeconds = Double(Defaults[.refreshInterval])
+        }
+        
+        lastRefreshTime = now
+        
+        let currentProcessKeys = Set(newPorts.map { $0.processKey })
+        let newlyAppearedProcessKeys = currentProcessKeys.subtracting(lastVisibleProcessKeys)
+        lastVisibleProcessKeys = currentProcessKeys
+        
+        for key in currentProcessKeys {
+            var stat = processFamiliarityData.stats[key] ?? ProcessSeenStat(
+                firstSeenAt: now,
+                lastSeenAt: now,
+                seenSeconds: 0
+            )
+            
+            if stat.firstSeenAt > now {
+                stat.firstSeenAt = now
+            }
+            
+            if newlyAppearedProcessKeys.contains(key) {
+                stat.lastSeenAt = now
+            }
+            stat.seenSeconds += deltaSeconds
+            
+            processFamiliarityData.stats[key] = stat
+        }
+        
+        processFamiliarityData.cleanup(keepDays: 90)
     }
 
     /// Kills the process using the specified port.

--- a/Sources/AppState+ProcessFamiliarity.swift
+++ b/Sources/AppState+ProcessFamiliarity.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+extension AppState {
+    private enum FamiliarityThreshold {
+        static let totalSeenHours: TimeInterval = 6
+        static let ageInDays: TimeInterval = 7
+        static let minimumSeenSeconds: TimeInterval = 1800
+    }
+    
+    func isFamiliar(_ port: PortInfo) -> Bool {
+        let key = port.processKey
+        
+        if processFamiliarityData.alwaysShowProcessKeys.contains(key) {
+            return false
+        }
+        
+        if processFamiliarityData.knownProcessKeys.contains(key) {
+            return true
+        }
+        
+        guard let stat = processFamiliarityData.stats[key] else {
+            return false
+        }
+        
+        let now = Date()
+        let totalSeenHours = stat.seenSeconds / 3600
+        let daysSinceFirstSeen = (now.timeIntervalSince1970 - stat.firstSeenAt.timeIntervalSince1970) / 86400
+        
+        if totalSeenHours >= FamiliarityThreshold.totalSeenHours {
+            return true
+        }
+        
+        if daysSinceFirstSeen >= FamiliarityThreshold.ageInDays && stat.seenSeconds >= FamiliarityThreshold.minimumSeenSeconds {
+            return true
+        }
+        
+        return false
+    }
+    
+    func markAsFamiliar(_ port: PortInfo) {
+        let key = port.processKey
+        processFamiliarityData.knownProcessKeys.insert(key)
+        processFamiliarityData.alwaysShowProcessKeys.remove(key)
+    }
+    
+    func markAsAlwaysShow(_ port: PortInfo) {
+        let key = port.processKey
+        processFamiliarityData.alwaysShowProcessKeys.insert(key)
+        processFamiliarityData.knownProcessKeys.remove(key)
+    }
+    
+    func removeFamiliarityMark(_ port: PortInfo) {
+        let key = port.processKey
+        processFamiliarityData.knownProcessKeys.remove(key)
+        processFamiliarityData.alwaysShowProcessKeys.remove(key)
+    }
+    
+    func resetLearnedFamiliarity() {
+        processFamiliarityData.stats.removeAll()
+        processFamiliarityData.knownProcessKeys.removeAll()
+        processFamiliarityData.alwaysShowProcessKeys.removeAll()
+    }
+    
+    func getProcessSeenStat(_ port: PortInfo) -> ProcessSeenStat? {
+        processFamiliarityData.stats[port.processKey]
+    }
+    
+    func sortByRecentAppearance(_ a: PortInfo, _ b: PortInfo) -> Bool {
+        let aStat = getProcessSeenStat(a)
+        let bStat = getProcessSeenStat(b)
+        let aTime = aStat?.lastSeenAt ?? Date()
+        let bTime = bStat?.lastSeenAt ?? Date()
+        
+        if aTime != bTime {
+            return aTime > bTime
+        }
+        return a.port < b.port
+    }
+}
+

--- a/Sources/Models/ProcessFamiliarity.swift
+++ b/Sources/Models/ProcessFamiliarity.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Defaults
+
+struct ProcessSeenStat: Codable, Equatable {
+    var firstSeenAt: Date
+    var lastSeenAt: Date
+    var seenSeconds: TimeInterval
+}
+
+struct ProcessFamiliarityData: Codable, Defaults.Serializable {
+    var stats: [String: ProcessSeenStat] = [:]
+    var knownProcessKeys: Set<String> = []
+    var alwaysShowProcessKeys: Set<String> = []
+    
+    mutating func cleanup(keepDays: Int = 90) {
+        let cutoff = Date().addingTimeInterval(-Double(keepDays * 24 * 60 * 60))
+        stats = stats.filter { $0.value.lastSeenAt > cutoff }
+    }
+}
+
+extension PortInfo {
+    var processKey: String {
+        let commandParts = command.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+        if let firstPart = commandParts.first {
+            let executable = String(firstPart)
+            if executable.hasPrefix("/") {
+                return "\(executable)|\(processName)"
+            }
+        }
+        return processName
+    }
+}
+

--- a/Sources/Views/MenuBar/MenuBarPortRow.swift
+++ b/Sources/Views/MenuBar/MenuBarPortRow.swift
@@ -41,6 +41,19 @@ struct MenuBarPortRow: View {
             Divider()
             Button { state.toggleWatch(port.port) } label: { Label(state.isWatching(port.port) ? "Stop Watching" : "Watch Port", systemImage: state.isWatching(port.port) ? "eye.slash" : "eye") }
             Divider()
+            
+            if state.isFamiliar(port) {
+                if state.processFamiliarityData.alwaysShowProcessKeys.contains(port.processKey) {
+                    Button { state.removeFamiliarityMark(port) } label: { Label("Remove Always Show", systemImage: "eye.slash") }
+                } else {
+                    Button { state.removeFamiliarityMark(port) } label: { Label("Remove Familiar Mark", systemImage: "xmark.circle") }
+                }
+            } else {
+                Button { state.markAsFamiliar(port) } label: { Label("Mark as Familiar (Hide)", systemImage: "eye.slash") }
+                Button { state.markAsAlwaysShow(port) } label: { Label("Always Show", systemImage: "eye.fill") }
+            }
+            
+            Divider()
             Button { if let url = URL(string: "http://localhost:\(port.port)") { NSWorkspace.shared.open(url) } } label: { Label("Open in Browser", systemImage: "globe.fill") }.keyboardShortcut("o", modifiers: .command)
             Button { NSPasteboard.general.clearContents(); NSPasteboard.general.setString("http://localhost:\(port.port)", forType: .string) } label: { Label("Copy URL", systemImage: "document.on.clipboard") }
 

--- a/Sources/Views/PortDetailView.swift
+++ b/Sources/Views/PortDetailView.swift
@@ -179,6 +179,44 @@ struct PortDetailView: View {
                     }
                     .buttonStyle(.bordered)
                 }
+                
+                HStack(spacing: 8) {
+                    if appState.isFamiliar(port) {
+                        if appState.processFamiliarityData.alwaysShowProcessKeys.contains(port.processKey) {
+                            Button {
+                                appState.removeFamiliarityMark(port)
+                            } label: {
+                                Text("Remove Always Show")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.bordered)
+                        } else {
+                            Button {
+                                appState.removeFamiliarityMark(port)
+                            } label: {
+                                Text("Remove Familiar Mark")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    } else {
+                        Button {
+                            appState.markAsFamiliar(port)
+                        } label: {
+                            Text("Mark as Familiar")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        
+                        Button {
+                            appState.markAsAlwaysShow(port)
+                        } label: {
+                            Text("Always Show")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
 
                 // Tunnel section
                 if port.isActive {

--- a/Sources/Views/PortTable/PortListRow.swift
+++ b/Sources/Views/PortTable/PortListRow.swift
@@ -164,6 +164,36 @@ struct PortListRow: View {
             }
 
             Divider()
+            
+            if appState.isFamiliar(port) {
+                if appState.processFamiliarityData.alwaysShowProcessKeys.contains(port.processKey) {
+                    Button {
+                        appState.removeFamiliarityMark(port)
+                    } label: {
+                        Label("Remove Always Show", systemImage: "eye.slash")
+                    }
+                } else {
+                    Button {
+                        appState.removeFamiliarityMark(port)
+                    } label: {
+                        Label("Remove Familiar Mark", systemImage: "xmark.circle")
+                    }
+                }
+            } else {
+                Button {
+                    appState.markAsFamiliar(port)
+                } label: {
+                    Label("Mark as Familiar (Hide)", systemImage: "eye.slash")
+                }
+                
+                Button {
+                    appState.markAsAlwaysShow(port)
+                } label: {
+                    Label("Always Show", systemImage: "eye.fill")
+                }
+            }
+
+            Divider()
 
             Button {
                 NSPasteboard.general.clearContents()

--- a/Sources/Views/PortTable/PortSortOptions.swift
+++ b/Sources/Views/PortTable/PortSortOptions.swift
@@ -15,6 +15,7 @@ import Foundation
 
 /// Available sort orders for port table
 enum SortOrder: String, CaseIterable {
+    case recent = "Recent"
     case port = "Port"
     case process = "Process"
     case pid = "PID"

--- a/Sources/Views/Settings/ProcessFamiliaritySettingsSection.swift
+++ b/Sources/Views/Settings/ProcessFamiliaritySettingsSection.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import Defaults
+
+struct ProcessFamiliaritySettingsSection: View {
+    @Bindable var appState: AppState
+    @State private var showResetConfirmation = false
+    
+    var body: some View {
+        SettingsGroup("Process Filtering", icon: "eye.slash.fill") {
+            VStack(spacing: 0) {
+                SettingsRowContainer {
+                    SettingsToggleRow(
+                        title: "Hide familiar processes",
+                        subtitle: "Automatically hide processes that are frequently seen",
+                        isOn: Binding(
+                            get: { appState.hideFamiliarProcesses },
+                            set: { appState.hideFamiliarProcesses = $0 }
+                        )
+                    )
+                }
+                
+                SettingsDivider()
+                
+                SettingsRowContainer {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Reset Learned Data")
+                                .fontWeight(.medium)
+                            Text("Clear all familiarity statistics and manual marks")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        
+                        Spacer()
+                        
+                        Button("Reset") {
+                            showResetConfirmation = true
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+            }
+        }
+        .confirmationDialog(
+            "Reset Learned Familiarity",
+            isPresented: $showResetConfirmation
+        ) {
+            Button("Reset", role: .destructive) {
+                appState.resetLearnedFamiliarity()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will clear all learned familiarity statistics and manual marks. This action cannot be undone.")
+        }
+    }
+}
+

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -34,6 +34,9 @@ struct SettingsView: View {
                 // MARK: - General
                 GeneralSettingsSection()
 
+                // MARK: - Process Filtering
+                ProcessFamiliaritySettingsSection(appState: state)
+
                 // MARK: - Port Forwarding
                 PortForwardingSettingsSection()
 


### PR DESCRIPTION
## Summary
This PR adds intelligent process filtering to reduce noise and improve usability by automatically hiding familiar processes and prioritizing newly appeared processes.

## Features
- ✨ **Automatic familiarity learning**: Processes seen for 6+ hours or 7+ days with 30+ minutes are automatically marked as familiar
- 🎯 **Manual marking**: Right-click context menu to mark processes as "Familiar (Hide)" or "Always Show"
- 📊 **Recent appearance sorting**: New "Recent" sort option (default) prioritizes newly appeared processes
- ⚙️ **Settings UI**: Toggle to enable/disable filtering and reset learned data
- 🛡️ **Protection rules**: Favorites and watched ports are never hidden

## Changes
- Added `ProcessFamiliarity` model for tracking process statistics
- Added `AppState+ProcessFamiliarity` extension for familiarity logic
- Updated `PortTableView` and `MenuBarView` to use recent sorting
- Added context menu actions in `PortListRow`, `MenuBarPortRow`, and `PortDetailView`
- Added `ProcessFamiliaritySettingsSection` in Settings

## Testing
- [x] Tested automatic learning with long-running processes
- [x] Tested manual marking via context menu
- [x] Tested recent sorting in both main window and menubar
- [x] Tested settings toggle and reset functionality
- [x] Verified favorites/watched ports are never hidden

## Screenshots
<img width="1692" height="676" alt="image" src="https://github.com/user-attachments/assets/6664f85e-6367-474f-b23d-51e6a4ef093e" />
