### PR TITLE
feat(macos): add system process hide toggle

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -10,6 +10,7 @@ extension Defaults.Keys {
     static let favorites = Key<Set<Int>>("favorites", default: [])
     static let watchedPorts = Key<[WatchedPort]>("watchedPorts", default: [])
     static let useTreeView = Key<Bool>("useTreeView", default: false)
+    static let hideSystemProcesses = Key<Bool>("hideSystemProcesses", default: false)
     static let refreshInterval = Key<Int>("refreshInterval", default: 5)
 
     // Sponsor-related keys
@@ -101,6 +102,10 @@ final class AppState {
 
         if filter.isActive {
             result = result.filter { filter.matches($0, favorites: favorites, watched: watchedPorts) }
+        }
+
+        if Defaults[.hideSystemProcesses] {
+            result = result.filter { $0.processType != .system }
         }
 
         return result

--- a/Sources/Views/Settings/GeneralSettingsSection.swift
+++ b/Sources/Views/Settings/GeneralSettingsSection.swift
@@ -7,8 +7,11 @@
 
 import SwiftUI
 import LaunchAtLogin
+import Defaults
 
 struct GeneralSettingsSection: View {
+    @Default(.hideSystemProcesses) private var hideSystemProcesses
+    
     var body: some View {
         SettingsGroup("General", icon: "gearshape.fill") {
             SettingsRowContainer {
@@ -23,6 +26,12 @@ struct GeneralSettingsSection: View {
                 }
                 .toggleStyle(.switch)
             }
+			
+			SettingsToggleRow(
+				title: "Hide System processes",
+				subtitle: "Hide macOS processes from the process list",
+				isOn: $hideSystemProcesses
+			)
         }
     }
 }


### PR DESCRIPTION
In relation to issue #63  i added  a setting to hide processes classified as "System" from the processes view, since killing those processes is usually not desirable and it's better to focus on the processes that are responsibility of the user itself

A further improvement could be doing a dropdown with ["No", "Menu Bar only", "All"] so a user can have the system processes shown in the main app but not in the menu app where just the important stuff is relevant, but i am not sure if adding all these edge cases is overkill