### PR TITLE
fix: remove Command String Truncation from Data Layer and Move Truncation Logic to View Layer

### DIFF
--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -62,7 +62,6 @@ actor PortScanner {
      * Executes: `ps -axo pid,command`
      *
      * This provides more detailed command information than lsof alone.
-     * Commands longer than 200 characters are truncated with "...".
      *
      * @returns Dictionary mapping PID to full command string
      */
@@ -102,7 +101,7 @@ actor PortScanner {
                       let pid = Int(parts[0]) else { continue }
 
                 let fullCommand = String(parts[1])
-                commands[pid] = fullCommand.count > 200 ? String(fullCommand.prefix(200)) + "..." : fullCommand
+                commands[pid] = fullCommand
             }
 
             return commands

--- a/Sources/Views/PortDetailView.swift
+++ b/Sources/Views/PortDetailView.swift
@@ -145,7 +145,9 @@ struct PortDetailView: View {
                 .controlSize(.small)
             }
 
-            Text(port.command)
+            Text(port.command.count > AppConstants.maxCommandLength
+                ? String(port.command.prefix(AppConstants.maxCommandLength)) + "..."
+                : port.command)
                 .font(.system(.caption, design: .monospaced))
                 .foregroundStyle(.secondary)
                 .textSelection(.enabled)


### PR DESCRIPTION
### Overview
This PR refactors the command string handling by removing truncation logic from the data layer (PortScanner) and moving it entirely to the view layer (PortDetailView). This ensures that complete command information is preserved at the data level while display truncation is handled at presentation time.

### Changes Made

#### 1. Data Layer (PortScanner.swift)
- **Removed**: Command string truncation logic from data model
- **Result**: Full command strings are now preserved without any truncation in the data layer
- The `getProcessCommands()` method continues to retrieve complete command information from the system
- Commands are stored in full in `PortInfo` objects

#### 2. View Layer (PortDetailView.swift)
- **Added**: Display truncation logic in the `commandSection` computed property
- **Implementation**: Uses `AppConstants.maxCommandLength` to truncate command strings only for display purposes
- **Logic**: 
  ```swift
  Text(port.command.count > AppConstants.maxCommandLength
      ? String(port.command.prefix(AppConstants.maxCommandLength)) + "..."
      : port.command)