### PR TITLE
feat(macos): ability to add custom kubernetes namespaces

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -13,6 +13,9 @@ extension Defaults.Keys {
     static let hideSystemProcesses = Key<Bool>("hideSystemProcesses", default: false)
     static let refreshInterval = Key<Int>("refreshInterval", default: 5)
 
+    // Kubernetes-related keys
+    static let customNamespaces = Key<[String]>("customNamespaces", default: [])
+
     // Sponsor-related keys
     static let sponsorCache = Key<SponsorCache?>("sponsorCache", default: nil)
     static let lastSponsorWindowShown = Key<Date?>("lastSponsorWindowShown", default: nil)

--- a/Sources/Models/KubernetesModels.swift
+++ b/Sources/Models/KubernetesModels.swift
@@ -4,8 +4,14 @@ import Foundation
 
 struct KubernetesNamespace: Identifiable, Codable, Sendable, Hashable {
     let name: String
+    let isCustom: Bool
 
     var id: String { name }
+
+    init(name: String, isCustom: Bool = false) {
+        self.name = name
+        self.isCustom = isCustom
+    }
 }
 
 // MARK: - Service

--- a/Sources/Views/PortForwarder/Browser/AddCustomNamespaceSheet.swift
+++ b/Sources/Views/PortForwarder/Browser/AddCustomNamespaceSheet.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct AddCustomNamespaceSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var namespaceInput: String = ""
+    @FocusState private var isInputFocused: Bool
+
+    let onAdd: ([String]) -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Add Custom Namespace")
+                .font(.headline)
+
+            Text("Enter namespace names (comma-separated for multiple)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            TextField("e.g., production, staging, dev", text: $namespaceInput)
+                .textFieldStyle(.roundedBorder)
+                .focused($isInputFocused)
+                .onSubmit {
+                    addNamespaces()
+                }
+
+            HStack {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button("Add") {
+                    addNamespaces()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(namespaceInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding()
+        .frame(width: 400)
+        .onAppear {
+            isInputFocused = true
+        }
+    }
+
+    private func addNamespaces() {
+        let names = namespaceInput
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard !names.isEmpty else { return }
+
+        onAdd(names)
+        dismiss()
+    }
+}

--- a/Sources/Views/PortForwarder/Browser/NamespacePanel.swift
+++ b/Sources/Views/PortForwarder/Browser/NamespacePanel.swift
@@ -6,6 +6,10 @@ struct NamespacePanel: View {
     let state: KubernetesDiscoveryState
     let onSelect: (KubernetesNamespace) -> Void
     let onRefresh: () -> Void
+    let onAddCustom: ([String]) -> Void
+    let onRemoveCustom: (KubernetesNamespace) -> Void
+
+    @State private var showingAddSheet = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -14,12 +18,20 @@ struct NamespacePanel: View {
                     .font(.headline)
                 Spacer()
                 Button {
+                    showingAddSheet = true
+                } label: {
+                    Image(systemName: "plus.circle")
+                }
+                .buttonStyle(.plain)
+                .help("Add custom namespace")
+                Button {
                     onRefresh()
                 } label: {
                     Image(systemName: "arrow.clockwise")
                 }
                 .buttonStyle(.plain)
                 .disabled(state == .loading)
+                .help("Refresh namespaces")
             }
             .padding(12)
 
@@ -43,8 +55,14 @@ struct NamespacePanel: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
-                    Button("Retry", action: onRefresh)
-                        .buttonStyle(.bordered)
+                    HStack(spacing: 8) {
+                        Button("Retry", action: onRefresh)
+                            .buttonStyle(.bordered)
+                        Button("Add Custom") {
+                            showingAddSheet = true
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
                     Spacer()
                 }
                 .padding()
@@ -54,6 +72,9 @@ struct NamespacePanel: View {
                         ForEach(namespaces) { ns in
                             Button { onSelect(ns) } label: {
                                 HStack {
+                                    Image(systemName: ns.isCustom ? "pencil.and.list.clipboard" : "folder")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
                                     Text(ns.name)
                                         .font(.system(.body, design: .monospaced))
                                     Spacer()
@@ -63,10 +84,20 @@ struct NamespacePanel: View {
                                 .background(selectedNamespace?.id == ns.id ? Color.accentColor.opacity(0.2) : Color.clear)
                             }
                             .buttonStyle(.plain)
+                            .contextMenu {
+                                if ns.isCustom {
+                                    Button("Remove", role: .destructive) {
+                                        onRemoveCustom(ns)
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
+        }
+        .sheet(isPresented: $showingAddSheet) {
+            AddCustomNamespaceSheet(onAdd: onAddCustom)
         }
     }
 }

--- a/Sources/Views/PortForwarder/ServiceBrowserView.swift
+++ b/Sources/Views/PortForwarder/ServiceBrowserView.swift
@@ -36,6 +36,12 @@ struct ServiceBrowserView: View {
                     },
                     onRefresh: {
                         Task { await discoveryManager.loadNamespaces() }
+                    },
+                    onAddCustom: { namespaceNames in
+                        discoveryManager.addCustomNamespaces(namespaceNames)
+                    },
+                    onRemoveCustom: { namespace in
+                        discoveryManager.removeCustomNamespace(namespace)
                     }
                 )
                 .frame(width: 180)

--- a/Sources/Views/PortForwarder/Tabs/ServiceBrowserTab.swift
+++ b/Sources/Views/PortForwarder/Tabs/ServiceBrowserTab.swift
@@ -65,6 +65,12 @@ struct ServiceBrowserEmbedded: View {
                     },
                     onRefresh: {
                         Task { await discoveryManager.loadNamespaces() }
+                    },
+                    onAddCustom: { namespaceNames in
+                        discoveryManager.addCustomNamespaces(namespaceNames)
+                    },
+                    onRemoveCustom: { namespace in
+                        discoveryManager.removeCustomNamespace(namespace)
                     }
                 )
                 .frame(width: 200)


### PR DESCRIPTION
Use case: Users may have access to certain namespaces but not permission to run `kubectl get namespaces`. This feature allows them to operate within their permitted namespaces despite that limitation.

Import From Kubernetes Window

<img width="790" height="488" alt="image" src="https://github.com/user-attachments/assets/d05f32e0-84ec-4a10-b6bb-f042731adf66" />

Custom Namespace Input Field

<img width="796" height="498" alt="image" src="https://github.com/user-attachments/assets/5fe35bec-4164-4758-abc8-029b98bcb980" />

Input Example

<img width="420" height="173" alt="image" src="https://github.com/user-attachments/assets/b01dc5bd-979b-420f-a472-1467f0b8b600" />


Different Icon and ability to delete custom added namespaces
<img width="799" height="495" alt="image" src="https://github.com/user-attachments/assets/9099ea7f-bdea-466b-bb08-cfa89d18bf13" />

Custom Namespaces will be shown in the configuration dropdown as well

<img width="1289" height="587" alt="image" src="https://github.com/user-attachments/assets/f5ca7562-cfd0-4286-aaac-8dcccf047cb9" />


