### PR TITLE
feat: add webhook notifications for port events

### DIFF
--- a/platforms/macos/Sources/AppState+PortOperations.swift
+++ b/platforms/macos/Sources/AppState+PortOperations.swift
@@ -23,6 +23,7 @@ extension AppState {
             // Check process type notifications for newly appeared ports
             if didChange {
                 checkProcessTypeNotifications(oldPorts: previousPorts, newPorts: scanned)
+                WebhookService.shared.checkPortChanges(oldPorts: previousPorts, newPorts: scanned)
             }
 
             // Always update watcher state to keep transition baseline accurate.
@@ -52,6 +53,7 @@ extension AppState {
     /// Kills the process using the specified port.
     func killPort(_ port: PortInfo) async {
         if await scanner.killProcessGracefully(pid: port.pid) {
+            WebhookService.shared.send(event: .portKilled, port: port)
             ports.removeAll { $0.id == port.id }
             await refresh()
         }
@@ -60,7 +62,10 @@ extension AppState {
     /// Kills the listening process and all processes with ESTABLISHED connections to the port.
     func killPortDeep(_ port: PortInfo) async {
         // 1. Kill the listener
-        _ = await scanner.killProcessGracefully(pid: port.pid)
+        let killed = await scanner.killProcessGracefully(pid: port.pid)
+        if killed {
+            WebhookService.shared.send(event: .portKilled, port: port)
+        }
 
         // 2. Find and kill ESTABLISHED connections
         let establishedPids = await scanner.findEstablishedPids(for: port.port)

--- a/platforms/macos/Sources/AppState.swift
+++ b/platforms/macos/Sources/AppState.swift
@@ -23,6 +23,10 @@ extension Defaults.Keys {
     // Process type notification filters (rawValues of enabled types, empty = disabled)
     static let notifyProcessTypes = Key<Set<String>>("notifyProcessTypes", default: [])
 
+    // Webhook configuration
+    static let webhookURL = Key<String>("webhookURL", default: "")
+    static let webhookEvents = Key<Set<WebhookEvent>>("webhookEvents", default: Set(WebhookEvent.allCases))
+
     // Kubernetes-related keys
     static let customNamespaces = Key<[String]>("customNamespaces", default: [])
 

--- a/platforms/macos/Sources/Models/WebhookConfig.swift
+++ b/platforms/macos/Sources/Models/WebhookConfig.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Defaults
+
+/// Events that can trigger webhook notifications
+enum WebhookEvent: String, CaseIterable, Codable, Sendable, Defaults.Serializable {
+    case portOpened = "port_opened"
+    case portClosed = "port_closed"
+    case portKilled = "port_killed"
+
+    var displayName: String {
+        switch self {
+        case .portOpened: "Port Opened"
+        case .portClosed: "Port Closed"
+        case .portKilled: "Port Killed"
+        }
+    }
+}
+
+/// Webhook payload sent to the configured URL
+struct WebhookPayload: Codable, Sendable {
+    let event: String
+    let port: Int
+    let process: String
+    let pid: Int
+    let timestamp: String
+    let hostname: String
+
+    static func create(event: WebhookEvent, port: PortInfo) -> WebhookPayload {
+        WebhookPayload(
+            event: event.rawValue,
+            port: port.port,
+            process: port.processName,
+            pid: port.pid,
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            hostname: ProcessInfo.processInfo.hostName
+        )
+    }
+}

--- a/platforms/macos/Sources/Services/WebhookService.swift
+++ b/platforms/macos/Sources/Services/WebhookService.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Defaults
+
+/// Service for sending webhook notifications on port events
+@MainActor
+final class WebhookService {
+    static let shared = WebhookService()
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    private init() {}
+
+    /// Sends a webhook for the given event and port info.
+    /// Silently fails if no webhook URL is configured or the URL is invalid.
+    func send(event: WebhookEvent, port: PortInfo) {
+        let enabledEvents = Defaults[.webhookEvents]
+        guard enabledEvents.contains(event) else { return }
+
+        let urlString = Defaults[.webhookURL].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !urlString.isEmpty, let url = URL(string: urlString) else { return }
+
+        let payload = WebhookPayload.create(event: event, port: port)
+
+        Task.detached { [encoder] in
+            do {
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.setValue("PortKiller/\(AppInfo.versionString)", forHTTPHeaderField: "User-Agent")
+                request.httpBody = try encoder.encode(payload)
+                request.timeoutInterval = 10
+
+                let (_, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse,
+                   !(200...299).contains(httpResponse.statusCode) {
+                    print("[Webhook] HTTP \(httpResponse.statusCode) for \(event.rawValue)")
+                }
+            } catch {
+                print("[Webhook] Failed to send \(event.rawValue): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Sends webhooks for newly opened ports by comparing old and new port lists.
+    func checkPortChanges(oldPorts: [PortInfo], newPorts: [PortInfo]) {
+        let enabledEvents = Defaults[.webhookEvents]
+        let urlString = Defaults[.webhookURL].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !urlString.isEmpty, !enabledEvents.isEmpty else { return }
+
+        let oldSet = Set(oldPorts.map { "\($0.port)-\($0.pid)" })
+        let newSet = Set(newPorts.map { "\($0.port)-\($0.pid)" })
+
+        // Port opened events
+        if enabledEvents.contains(.portOpened) {
+            for port in newPorts {
+                let key = "\(port.port)-\(port.pid)"
+                if !oldSet.contains(key) {
+                    send(event: .portOpened, port: port)
+                }
+            }
+        }
+
+        // Port closed events
+        if enabledEvents.contains(.portClosed) {
+            for port in oldPorts {
+                let key = "\(port.port)-\(port.pid)"
+                if !newSet.contains(key) {
+                    send(event: .portClosed, port: port)
+                }
+            }
+        }
+    }
+
+    /// Sends a test webhook with dummy data to verify the configuration.
+    func sendTest() async -> Bool {
+        let urlString = Defaults[.webhookURL].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !urlString.isEmpty, let url = URL(string: urlString) else { return false }
+
+        let payload = WebhookPayload(
+            event: "test",
+            port: 8080,
+            process: "PortKiller",
+            pid: Int(ProcessInfo.processInfo.processIdentifier),
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            hostname: ProcessInfo.processInfo.hostName
+        )
+
+        do {
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("PortKiller/\(AppInfo.versionString)", forHTTPHeaderField: "User-Agent")
+            request.httpBody = try encoder.encode(payload)
+            request.timeoutInterval = 10
+
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse {
+                return (200...299).contains(httpResponse.statusCode)
+            }
+            return false
+        } catch {
+            return false
+        }
+    }
+}

--- a/platforms/macos/Sources/Views/Settings/SettingsView.swift
+++ b/platforms/macos/Sources/Views/Settings/SettingsView.swift
@@ -39,6 +39,9 @@ struct SettingsView: View {
                 // MARK: - Notifications
                 NotificationsSettingsSection()
 
+                // MARK: - Webhooks
+                WebhookSettingsSection()
+
                 // MARK: - Cloudflare Tunnels
                 CloudflaredSettingsSection()
 

--- a/platforms/macos/Sources/Views/Settings/WebhookSettingsSection.swift
+++ b/platforms/macos/Sources/Views/Settings/WebhookSettingsSection.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import Defaults
+
+struct WebhookSettingsSection: View {
+    @Default(.webhookURL) private var webhookURL
+    @Default(.webhookEvents) private var webhookEvents
+    @State private var testResult: TestResult?
+    @State private var isTesting = false
+
+    private enum TestResult {
+        case success, failure
+    }
+
+    var body: some View {
+        SettingsGroup("Webhooks", icon: "arrow.up.forward.app") {
+            VStack(spacing: 0) {
+                // URL field
+                SettingsRowContainer {
+                    VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Webhook URL")
+                                .fontWeight(.medium)
+                            Text("Send JSON POST requests when port events occur")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        HStack(spacing: 8) {
+                            TextField("https://hooks.slack.com/services/...", text: $webhookURL)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(.body, design: .monospaced))
+
+                            if !webhookURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                Button {
+                                    webhookURL = ""
+                                    testResult = nil
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+
+                        // Test button and result
+                        if !webhookURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            HStack(spacing: 8) {
+                                Button {
+                                    testWebhook()
+                                } label: {
+                                    HStack(spacing: 4) {
+                                        if isTesting {
+                                            ProgressView()
+                                                .controlSize(.small)
+                                        }
+                                        Text("Test Webhook")
+                                    }
+                                }
+                                .disabled(isTesting)
+                                .controlSize(.small)
+
+                                if let result = testResult {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: result == .success ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                        Text(result == .success ? "Success" : "Failed")
+                                    }
+                                    .font(.caption)
+                                    .foregroundStyle(result == .success ? .green : .red)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                SettingsDivider()
+
+                // Event toggles
+                SettingsRowContainer {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Events")
+                            .fontWeight(.medium)
+
+                        ForEach(WebhookEvent.allCases, id: \.self) { event in
+                            Toggle(isOn: eventBinding(for: event)) {
+                                Text(event.displayName)
+                                    .font(.callout)
+                            }
+                            .toggleStyle(.checkbox)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func eventBinding(for event: WebhookEvent) -> Binding<Bool> {
+        Binding(
+            get: { webhookEvents.contains(event) },
+            set: { enabled in
+                if enabled {
+                    webhookEvents.insert(event)
+                } else {
+                    webhookEvents.remove(event)
+                }
+            }
+        )
+    }
+
+    private func testWebhook() {
+        isTesting = true
+        testResult = nil
+        Task {
+            let success = await WebhookService.shared.sendTest()
+            isTesting = false
+            testResult = success ? .success : .failure
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds configurable webhook URL in Settings to receive JSON POST notifications
- Supports three event types: `port_opened`, `port_closed`, `port_killed`
- Per-event toggle checkboxes to control which events trigger webhooks
- "Test Webhook" button to verify configuration with a test payload
- Webhooks fire on port scan changes and process kills

### Payload Format
```json
{
  "event": "port_opened",
  "port": 3000,
  "process": "node",
  "pid": 12345,
  "timestamp": "2025-01-15T10:30:00Z",
  "hostname": "MacBook-Pro.local"
}
```

Closes #29

## Test plan
- [ ] Set a webhook URL in Settings > Webhooks
- [ ] Click "Test Webhook" — verify success indicator
- [ ] Start a process on a port — verify `port_opened` webhook fires
- [ ] Stop that process — verify `port_closed` webhook fires
- [ ] Kill a process via PortKiller — verify `port_killed` webhook fires
- [ ] Disable specific events — verify they no longer fire
- [ ] Clear URL — verify no webhooks are sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)