### PR TITLE
feat: add request log monitoring for Cloudflare tunnels

### DIFF
--- a/platforms/macos/Sources/Managers/TunnelManager.swift
+++ b/platforms/macos/Sources/Managers/TunnelManager.swift
@@ -135,6 +135,16 @@ final class TunnelManager {
             }
             await self.cloudflaredService.setErrorHandler(for: tunnelState.id, handler: errorHandler)
 
+            // Set log handler to capture all output lines
+            let logHandler: @Sendable (String) -> Void = { [weak tunnelState] line in
+                guard let tunnelState = tunnelState else { return }
+                let entry = TunnelLogEntry.parse(line)
+                Task { @MainActor [weak tunnelState] in
+                    tunnelState?.addLogEntry(entry)
+                }
+            }
+            await self.cloudflaredService.setLogHandler(for: tunnelState.id, handler: logHandler)
+
             do {
                 let process = try await self.cloudflaredService.startTunnel(id: tunnelState.id, port: port)
                 try? await Task.sleep(for: .seconds(3))

--- a/platforms/macos/Sources/Models/CloudflareTunnel.swift
+++ b/platforms/macos/Sources/Models/CloudflareTunnel.swift
@@ -34,6 +34,23 @@ final class CloudflareTunnelState: Identifiable, Sendable {
     var tunnelURL: String?
     var lastError: String?
     var startTime: Date?
+    var logs: [TunnelLogEntry] = []
+
+    /// Maximum number of log entries to keep per tunnel
+    private static let maxLogEntries = 500
+
+    /// Adds a log entry, keeping the buffer bounded
+    func addLogEntry(_ entry: TunnelLogEntry) {
+        logs.append(entry)
+        if logs.count > Self.maxLogEntries {
+            logs.removeFirst(logs.count - Self.maxLogEntries)
+        }
+    }
+
+    /// Clears all log entries
+    func clearLogs() {
+        logs.removeAll()
+    }
 
     init(id: UUID = UUID(), port: Int, portInfoId: String? = nil) {
         self.id = id

--- a/platforms/macos/Sources/Models/TunnelLogEntry.swift
+++ b/platforms/macos/Sources/Models/TunnelLogEntry.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A log entry from cloudflared tunnel output
+@Observable
+@MainActor
+final class TunnelLogEntry: Identifiable, Sendable {
+    let id = UUID()
+    let timestamp: Date
+    let message: String
+    let level: LogLevel
+
+    nonisolated init(timestamp: Date = Date(), message: String, level: LogLevel = .info) {
+        self.timestamp = timestamp
+        self.message = message
+        self.level = level
+    }
+
+    enum LogLevel: Sendable {
+        case info
+        case warning
+        case error
+        case request
+
+        var color: String {
+            switch self {
+            case .info: "secondary"
+            case .warning: "orange"
+            case .error: "red"
+            case .request: "blue"
+            }
+        }
+    }
+
+    /// Parses a cloudflared log line to determine level and clean message.
+    nonisolated static func parse(_ line: String) -> TunnelLogEntry {
+        let lowered = line.lowercased()
+
+        let level: LogLevel
+        if lowered.contains("error") || lowered.contains("failed") || lowered.contains("unable to") {
+            level = .error
+        } else if lowered.contains("warn") {
+            level = .warning
+        } else if lowered.contains("request") || lowered.contains("200") || lowered.contains("404") ||
+                    lowered.contains("get ") || lowered.contains("post ") || lowered.contains("put ") ||
+                    lowered.contains("delete ") || lowered.contains("status") {
+            level = .request
+        } else {
+            level = .info
+        }
+
+        return TunnelLogEntry(message: line, level: level)
+    }
+}

--- a/platforms/macos/Sources/Services/CloudflaredService.swift
+++ b/platforms/macos/Sources/Services/CloudflaredService.swift
@@ -10,6 +10,7 @@ actor CloudflaredService {
     private var outputTasks: [UUID: Task<Void, Never>] = [:]
     private var urlHandlers: [UUID: @Sendable (String) -> Void] = [:]
     private var errorHandlers: [UUID: @Sendable (String) -> Void] = [:]
+    private var logHandlers: [UUID: @Sendable (String) -> Void] = [:]
 
     // MARK: - Dependency Check
 
@@ -58,9 +59,14 @@ actor CloudflaredService {
         errorHandlers[id] = handler
     }
 
+    func setLogHandler(for id: UUID, handler: @escaping @Sendable (String) -> Void) {
+        logHandlers[id] = handler
+    }
+
     func removeHandlers(for id: UUID) {
         urlHandlers.removeValue(forKey: id)
         errorHandlers.removeValue(forKey: id)
+        logHandlers.removeValue(forKey: id)
     }
 
     // MARK: - Tunnel Management
@@ -152,6 +158,9 @@ actor CloudflaredService {
     }
 
     private func parseLine(_ line: String, for id: UUID) {
+        // Forward all lines to log handler
+        logHandlers[id]?(line)
+
         // cloudflared outputs the URL like:
         // "Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):
         // https://something-random.trycloudflare.com"

--- a/platforms/macos/Sources/Views/CloudflareTunnels/CloudflareTunnelsView.swift
+++ b/platforms/macos/Sources/Views/CloudflareTunnels/CloudflareTunnelsView.swift
@@ -118,56 +118,75 @@ struct CloudflareTunnelRow: View {
     @Environment(AppState.self) private var appState
     @State private var isHovered = false
     @State private var isCopied = false
+    @State private var showLogs = false
 
     var body: some View {
-        HStack(spacing: 12) {
-            // Status indicator
-            statusIndicator
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                // Status indicator
+                statusIndicator
 
-            // Port info
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Port " + String(tunnel.port))
-                    .font(.headline)
+                // Port info
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Port " + String(tunnel.port))
+                        .font(.headline)
 
-                if let url = tunnel.tunnelURL {
-                    Text(url)
-                        .font(.caption)
-                        .foregroundStyle(.blue)
-                        .lineLimit(1)
-                } else if tunnel.status == .starting {
-                    Text("Starting tunnel...")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                } else if let error = tunnel.lastError {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .lineLimit(1)
+                    if let url = tunnel.tunnelURL {
+                        Text(url)
+                            .font(.caption)
+                            .foregroundStyle(.blue)
+                            .lineLimit(1)
+                    } else if tunnel.status == .starting {
+                        Text("Starting tunnel...")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if let error = tunnel.lastError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .lineLimit(1)
+                    }
                 }
-            }
 
-            Spacer()
+                Spacer()
 
-            // Actions
-            if tunnel.status == .active, tunnel.tunnelURL != nil {
-                actionButtons
-            } else if tunnel.status == .starting {
-                ProgressView()
-                    .controlSize(.small)
-            }
+                // Actions
+                if tunnel.status == .active, tunnel.tunnelURL != nil {
+                    actionButtons
+                } else if tunnel.status == .starting {
+                    ProgressView()
+                        .controlSize(.small)
+                }
 
-            // Stop button
-            Button {
-                appState.tunnelManager.stopTunnel(id: tunnel.id)
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(.red)
+                // Log toggle
+                Button {
+                    showLogs.toggle()
+                } label: {
+                    Image(systemName: "doc.text")
+                        .foregroundColor(showLogs ? .accentColor : .secondary)
+                }
+                .buttonStyle(.plain)
+                .help(showLogs ? "Hide logs" : "Show logs")
+
+                // Stop button
+                Button {
+                    appState.tunnelManager.stopTunnel(id: tunnel.id)
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.plain)
+                .help("Stop tunnel")
             }
-            .buttonStyle(.plain)
-            .help("Stop tunnel")
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+
+            if showLogs {
+                Divider()
+                TunnelLogView(tunnel: tunnel)
+                    .frame(height: 200)
+            }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
         .background(isHovered ? Color.primary.opacity(0.05) : Color.clear)
         .onHover { hovering in
             isHovered = hovering
@@ -190,6 +209,14 @@ struct CloudflareTunnelRow: View {
 
                 Divider()
             }
+
+            Button {
+                showLogs.toggle()
+            } label: {
+                Label(showLogs ? "Hide Logs" : "Show Logs", systemImage: "doc.text")
+            }
+
+            Divider()
 
             Button(role: .destructive) {
                 appState.tunnelManager.stopTunnel(id: tunnel.id)

--- a/platforms/macos/Sources/Views/CloudflareTunnels/TunnelLogView.swift
+++ b/platforms/macos/Sources/Views/CloudflareTunnels/TunnelLogView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct TunnelLogView: View {
+    let tunnel: CloudflareTunnelState
+    @State private var searchText = ""
+    @State private var filterLevel: TunnelLogEntry.LogLevel?
+
+    private var filteredLogs: [TunnelLogEntry] {
+        var logs = tunnel.logs
+        if let level = filterLevel {
+            logs = logs.filter { $0.level == level }
+        }
+        if !searchText.isEmpty {
+            logs = logs.filter { $0.message.localizedCaseInsensitiveContains(searchText) }
+        }
+        return logs
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Toolbar
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search logs...", text: $searchText)
+                    .textFieldStyle(.plain)
+
+                Spacer()
+
+                // Level filter
+                Picker("", selection: $filterLevel) {
+                    Text("All").tag(nil as TunnelLogEntry.LogLevel?)
+                    Text("Requests").tag(TunnelLogEntry.LogLevel.request as TunnelLogEntry.LogLevel?)
+                    Text("Errors").tag(TunnelLogEntry.LogLevel.error as TunnelLogEntry.LogLevel?)
+                    Text("Warnings").tag(TunnelLogEntry.LogLevel.warning as TunnelLogEntry.LogLevel?)
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 280)
+
+                Text("\(filteredLogs.count) entries")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 70, alignment: .trailing)
+
+                Button {
+                    tunnel.clearLogs()
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Clear logs")
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Color(nsColor: .controlBackgroundColor))
+
+            Divider()
+
+            // Log entries
+            if filteredLogs.isEmpty {
+                ContentUnavailableView {
+                    Label("No Logs", systemImage: "doc.text")
+                } description: {
+                    Text(tunnel.logs.isEmpty ? "Logs will appear here as requests come in" : "No logs match the current filter")
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(filteredLogs) { entry in
+                                logEntryRow(entry)
+                                    .id(entry.id)
+                            }
+                        }
+                    }
+                    .onChange(of: tunnel.logs.count) { _, _ in
+                        if let last = filteredLogs.last {
+                            proxy.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func logEntryRow(_ entry: TunnelLogEntry) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            // Timestamp
+            Text(Self.timeFormatter.string(from: entry.timestamp))
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.tertiary)
+                .frame(width: 80, alignment: .leading)
+
+            // Level indicator
+            Circle()
+                .fill(levelColor(entry.level))
+                .frame(width: 6, height: 6)
+                .padding(.top, 4)
+
+            // Message
+            Text(entry.message)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(entry.level == .error ? .red : .primary)
+                .lineLimit(3)
+                .textSelection(.enabled)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 3)
+    }
+
+    private func levelColor(_ level: TunnelLogEntry.LogLevel) -> Color {
+        switch level {
+        case .info: .secondary
+        case .warning: .orange
+        case .error: .red
+        case .request: .blue
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Per-tunnel log viewer showing all cloudflared output in real-time
- Logs categorized by level: info, warning, error, request (with color coding)
- Search and filter logs by level or keyword
- Auto-scrolling to latest entries
- Log buffer capped at 500 entries per tunnel to prevent memory issues
- Clear logs button and context menu toggle
- Log toggle button on each tunnel row in the Cloudflare Tunnels view

Closes #46

## Test plan
- [ ] Start a Cloudflare tunnel from the tunnel view
- [ ] Click the log icon on the tunnel row — log panel appears
- [ ] Verify cloudflared output appears in real-time
- [ ] Search logs using the search field
- [ ] Filter by level (All, Requests, Errors, Warnings)
- [ ] Verify auto-scroll works as new entries arrive
- [ ] Clear logs via trash icon
- [ ] Right-click tunnel row → "Show Logs" / "Hide Logs" works
- [ ] Stop tunnel and verify log view handles it gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)