### PR TITLE
feat: support named Cloudflare tunnels

### DIFF
--- a/platforms/macos/Sources/AppState.swift
+++ b/platforms/macos/Sources/AppState.swift
@@ -88,6 +88,15 @@ final class AppState {
     /// ID of the currently selected port-forward connection
     var selectedPortForwardConnectionId: UUID? = nil
 
+    /// Tunnel UUID of the currently selected named tunnel (for the right-pane detail view).
+    var selectedNamedTunnelID: String? = nil
+
+    /// The currently selected named tunnel, if any.
+    var selectedNamedTunnel: NamedCloudflareTunnel? {
+        guard let id = selectedNamedTunnelID else { return nil }
+        return namedTunnelManager.tunnels.first { $0.tunnelID == id }
+    }
+
     /// The currently selected port-forward connection, if any
     var selectedPortForwardConnection: PortForwardConnectionState? {
         guard let id = selectedPortForwardConnectionId else { return nil }
@@ -210,8 +219,11 @@ final class AppState {
     /// Manages Kubernetes port-forward connections
     let portForwardManager = PortForwardManager()
 
-    /// Manages Cloudflare tunnel connections
-    let tunnelManager = TunnelManager()
+    /// Manages Cloudflare Quick Tunnel connections (ephemeral `*.trycloudflare.com`)
+    let tunnelManager: TunnelManager
+
+    /// Manages persistent (named) Cloudflare tunnels discovered from `~/.cloudflared/`
+    let namedTunnelManager: NamedTunnelManager
 
     // MARK: - Internal Properties (for extensions)
 
@@ -233,6 +245,10 @@ final class AppState {
         self.scanner = scanner
         self.favoritesState = favoritesState ?? FavoritesState()
         self.watchedPortsState = watchedPortsState ?? WatchedPortsState()
+
+        let cloudflared = CloudflaredService()
+        self.tunnelManager = TunnelManager(cloudflaredService: cloudflared)
+        self.namedTunnelManager = NamedTunnelManager(cloudflaredService: cloudflared)
 
         setupKeyboardShortcuts()
         startAutoRefresh()

--- a/platforms/macos/Sources/Managers/NamedTunnelManager.swift
+++ b/platforms/macos/Sources/Managers/NamedTunnelManager.swift
@@ -1,0 +1,359 @@
+import Foundation
+
+// MARK: - Port Exposure
+
+/// A single (hostname, tunnel) pair exposing a local port through cloudflared.
+struct PortExposure: Hashable, Sendable {
+    let hostname: String
+    let publicURL: String
+    let tunnelName: String
+    let tunnelID: String
+}
+
+// MARK: - Named Tunnel Manager
+
+/// Manages discovery and lifecycle of persistent (named) Cloudflare tunnels.
+///
+/// Unlike `TunnelManager` (Quick Tunnels — ephemeral `*.trycloudflare.com` URLs), this
+/// works with tunnels created via `cloudflared tunnel create`, identified by a stable
+/// UUID, and run via `cloudflared tunnel run <name>`.
+@Observable
+@MainActor
+final class NamedTunnelManager {
+    /// Discovered tunnels, keyed implicitly by `tunnelID`.
+    var tunnels: [NamedCloudflareTunnel] = []
+    var isDiscovering: Bool = false
+    var hasDiscovered: Bool = false
+
+    private let cloudflaredService: CloudflaredService
+    private let discoveryService: CloudflaredDiscoveryService
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
+
+    init(
+        cloudflaredService: CloudflaredService,
+        discoveryService: CloudflaredDiscoveryService = CloudflaredDiscoveryService()
+    ) {
+        self.cloudflaredService = cloudflaredService
+        self.discoveryService = discoveryService
+    }
+
+    deinit {
+        refreshTask?.cancel()
+    }
+
+    /// Start best-effort discovery while the Cloudflare Tunnels UI is visible.
+    ///
+    /// We avoid doing this from app launch because `cloudflared tunnel list` can hit
+    /// the user's Cloudflare account, and that should only happen when the user
+    /// opens tunnel management UI or explicitly refreshes.
+    func startRefreshing() {
+        discoverIfNeeded()
+        guard refreshTask == nil else { return }
+
+        refreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(30))
+                guard let self = self else { return }
+                if self.isDiscovering { continue }
+                await self.discoverAsync()
+            }
+        }
+    }
+
+    func stopRefreshing() {
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+
+    // MARK: - Computed
+
+    var runningCount: Int {
+        tunnels.filter { $0.status == .running }.count
+    }
+
+    var isLoggedIn: Bool {
+        discoveryService.isLoggedIn
+    }
+
+    /// All public hostnames exposed for a given local port across currently running tunnels.
+    /// Returns an empty array if no running tunnel maps to that port.
+    func exposures(for localPort: Int) -> [PortExposure] {
+        var result: [PortExposure] = []
+        for tunnel in tunnels where tunnel.status == .running {
+            for rule in tunnel.ingressRules {
+                guard rule.localPort == localPort,
+                      let hostname = rule.hostname,
+                      let publicURL = rule.publicURL else { continue }
+                result.append(PortExposure(
+                    hostname: hostname,
+                    publicURL: publicURL,
+                    tunnelName: tunnel.name,
+                    tunnelID: tunnel.tunnelID
+                ))
+            }
+        }
+        return result
+    }
+
+    // MARK: - Discovery
+
+    func discover(force: Bool = false) {
+        guard force || !isDiscovering else { return }
+        Task { await discoverAsync() }
+    }
+
+    func discoverIfNeeded() {
+        guard !hasDiscovered else { return }
+        discover()
+    }
+
+    func discoverAsync() async {
+        guard !isDiscovering else { return }
+        isDiscovering = true
+        defer {
+            isDiscovering = false
+            hasDiscovered = true
+        }
+
+        let cloudflaredPath = cloudflaredService.cloudflaredPath
+        let discovered = await discoveryService.discover(cloudflaredPath: cloudflaredPath)
+
+        // Merge with existing tunnels, preserving runtime state for ones we're currently running.
+        var existingByID: [String: NamedCloudflareTunnel] = [:]
+        for t in tunnels { existingByID[t.tunnelID] = t }
+
+        var merged: [NamedCloudflareTunnel] = []
+        for d in discovered {
+            let tunnel: NamedCloudflareTunnel
+            if let existing = existingByID[d.tunnelID] {
+                tunnel = existing
+                tunnel.credentialsPath = d.credentialsPath
+                tunnel.edgeConnections = d.edgeConnections
+                // Only overwrite ingress from config.yml if we haven't picked up a runtime version.
+                if tunnel.ingressSource != .runtimeLog, !d.localIngress.isEmpty {
+                    tunnel.ingressRules = d.localIngress
+                    tunnel.ingressSource = .localConfig
+                }
+            } else {
+                tunnel = NamedCloudflareTunnel(tunnelID: d.tunnelID, name: d.name, createdAt: d.createdAt)
+                tunnel.credentialsPath = d.credentialsPath
+                tunnel.edgeConnections = d.edgeConnections
+                if !d.localIngress.isEmpty {
+                    tunnel.ingressRules = d.localIngress
+                    tunnel.ingressSource = .localConfig
+                }
+            }
+            // Sticky flag: once we've seen this tunnel referenced by config.yml, remember it
+            // even if a later runtime config replaces ingressRules. Otherwise we'd misclassify
+            // it as `.managedElsewhere` after it connects and acquires its own edge connections.
+            if !d.localIngress.isEmpty {
+                tunnel.hasLocalConfigMatch = true
+            }
+            merged.append(tunnel)
+        }
+
+        // Keep tunnels that are currently running locally even if they were de-listed remotely.
+        for existing in tunnels where existing.status == .running || existing.status == .starting {
+            if !merged.contains(where: { $0.tunnelID == existing.tunnelID }) {
+                merged.append(existing)
+            }
+        }
+
+        tunnels = merged.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    // MARK: - Run / Stop
+
+    func run(_ tunnel: NamedCloudflareTunnel, allowManagedElsewhere: Bool = false) {
+        guard tunnel.status != .running, tunnel.status != .starting else { return }
+        // Warn by default before adding this Mac as another connector for a
+        // tunnel that already appears to be managed by a different origin.
+        guard allowManagedElsewhere || tunnel.runSafety != .managedElsewhere else {
+            tunnel.lastError = "Tunnel is managed elsewhere (active edge connections from other origins)."
+            return
+        }
+
+        let runID = UUID()
+        tunnel.runID = runID
+        tunnel.status = .starting
+        tunnel.lastError = nil
+        tunnel.metricsPort = nil
+        tunnel.activeConnectionCount = 0
+
+        Task { [weak self, weak tunnel] in
+            guard let self = self, let tunnel = tunnel else { return }
+            await self.startNamedTunnel(runID: runID, tunnel: tunnel)
+        }
+    }
+
+    func stop(_ tunnel: NamedCloudflareTunnel) {
+        guard let runID = tunnel.runID else { return }
+        tunnel.status = .stopping
+        Task { [weak tunnel] in
+            await self.cloudflaredService.stopTunnel(id: runID)
+            await MainActor.run {
+                guard let tunnel = tunnel else { return }
+                tunnel.runID = nil
+                tunnel.status = .stopped
+                tunnel.activeConnectionCount = 0
+                tunnel.metricsPort = nil
+            }
+        }
+    }
+
+    func stopAll() async {
+        let running = tunnels.filter { $0.runID != nil }
+        for tunnel in running {
+            tunnel.status = .stopping
+        }
+        for tunnel in running {
+            if let id = tunnel.runID {
+                await cloudflaredService.stopTunnel(id: id)
+            }
+        }
+        for tunnel in running {
+            tunnel.runID = nil
+            tunnel.status = .stopped
+            tunnel.activeConnectionCount = 0
+            tunnel.metricsPort = nil
+        }
+    }
+
+    // MARK: - Internal
+
+    private func startNamedTunnel(runID: UUID, tunnel: NamedCloudflareTunnel) async {
+        // Log handler: capture every line, parse for state transitions.
+        let logHandler: @Sendable (String) -> Void = { [weak self, weak tunnel] line in
+            let entry = TunnelLogEntry.parse(line)
+            Task { @MainActor [weak self, weak tunnel] in
+                guard let tunnel = tunnel else { return }
+                tunnel.addLogEntry(entry)
+                self?.applyLogLine(line, to: tunnel)
+            }
+        }
+        await cloudflaredService.setLogHandler(for: runID, handler: logHandler)
+
+        let errorHandler: @Sendable (String) -> Void = { [weak tunnel] message in
+            Task { @MainActor [weak tunnel] in
+                guard let tunnel = tunnel else { return }
+                tunnel.lastError = message
+                if tunnel.status != .running {
+                    tunnel.status = .error
+                }
+            }
+        }
+        await cloudflaredService.setErrorHandler(for: runID, handler: errorHandler)
+
+        do {
+            let process = try await cloudflaredService.runNamedTunnel(id: runID, tunnelName: tunnel.name)
+            tunnel.startedAt = Date()
+            // Give it ~3s to register at least one connection; otherwise leave it in .starting and
+            // let log parsing flip to .running when "Registered tunnel connection" arrives.
+            try? await Task.sleep(for: .seconds(3))
+
+            if !process.isRunning && tunnel.status != .running {
+                await cloudflaredService.removeHandlers(for: runID)
+                tunnel.status = .error
+                if tunnel.lastError == nil {
+                    tunnel.lastError = "cloudflared exited unexpectedly"
+                }
+                tunnel.runID = nil
+                return
+            }
+
+            await monitorProcess(process, runID: runID, tunnel: tunnel)
+        } catch {
+            await cloudflaredService.removeHandlers(for: runID)
+            tunnel.status = .error
+            tunnel.lastError = error.localizedDescription
+            tunnel.runID = nil
+        }
+    }
+
+    private func monitorProcess(_ process: Process, runID: UUID, tunnel: NamedCloudflareTunnel) async {
+        while process.isRunning && !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(1))
+        }
+
+        guard tunnel.runID == runID else { return }
+        await cloudflaredService.removeHandlers(for: runID)
+
+        tunnel.runID = nil
+        tunnel.activeConnectionCount = 0
+        tunnel.metricsPort = nil
+
+        if tunnel.status == .stopping || process.terminationStatus == 0 {
+            tunnel.status = .stopped
+        } else {
+            tunnel.status = .error
+            if tunnel.lastError == nil {
+                tunnel.lastError = "cloudflared exited with status \(process.terminationStatus)"
+            }
+        }
+    }
+
+    /// Parse meaningful state out of cloudflared log lines.
+    private func applyLogLine(_ line: String, to tunnel: NamedCloudflareTunnel) {
+        // First successful registration flips us into Running.
+        if line.contains("Registered tunnel connection") {
+            tunnel.activeConnectionCount += 1
+            if tunnel.status != .running {
+                tunnel.status = .running
+            }
+        } else if line.contains("Unregistered tunnel connection") {
+            tunnel.activeConnectionCount = max(0, tunnel.activeConnectionCount - 1)
+        }
+
+        // Metrics server port — looks like:
+        //   "Starting metrics server on 127.0.0.1:20241/metrics"
+        if line.contains("Starting metrics server on"),
+           let port = parseMetricsPort(from: line) {
+            tunnel.metricsPort = port
+        }
+
+        // Runtime ingress config from the dashboard arrives as:
+        //   "Updated to new configuration config=\"{...}\" version=N"
+        if line.contains("Updated to new configuration"),
+           let rules = parseRuntimeIngress(from: line) {
+            tunnel.ingressRules = rules
+            tunnel.ingressSource = .runtimeLog
+        }
+    }
+
+    private func parseMetricsPort(from line: String) -> Int? {
+        // Match `127.0.0.1:NNNNN`
+        let pattern = #"127\.0\.0\.1:(\d+)"#
+        guard let range = line.range(of: pattern, options: .regularExpression) else { return nil }
+        let matched = String(line[range])
+        guard let colonIdx = matched.firstIndex(of: ":") else { return nil }
+        let portPart = matched[matched.index(after: colonIdx)...]
+        // Strip trailing non-digits (e.g. "/metrics").
+        let digits = portPart.prefix { $0.isNumber }
+        return Int(digits)
+    }
+
+    private func parseRuntimeIngress(from line: String) -> [CloudflareTunnelIngressRule]? {
+        // The cloudflared log embeds the config JSON inside double quotes with escaped quotes:
+        //   config="{\"ingress\":[{\"hostname\":\"foo\",\"service\":\"http://localhost:3000\"}, ...]}"
+        // We need to extract the JSON string, unescape it, and parse.
+        guard let configRange = line.range(of: "config=\"") else { return nil }
+        let afterPrefix = line[configRange.upperBound...]
+        // The JSON ends at the last `"` before ` version=` (or end of line).
+        let endMarker = afterPrefix.range(of: "\" version=") ?? afterPrefix.range(of: "\"", options: .backwards)
+        guard let end = endMarker else { return nil }
+        let escapedJSON = String(afterPrefix[..<end.lowerBound])
+        let unescaped = escapedJSON
+            .replacingOccurrences(of: "\\\"", with: "\"")
+            .replacingOccurrences(of: "\\\\", with: "\\")
+        guard let data = unescaped.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let ingress = json["ingress"] as? [[String: Any]] else { return nil }
+
+        return ingress.compactMap { entry -> CloudflareTunnelIngressRule? in
+            let hostname = entry["hostname"] as? String
+            let path = entry["path"] as? String
+            guard let service = entry["service"] as? String else { return nil }
+            return CloudflareTunnelIngressRule(hostname: hostname, path: path, service: service)
+        }
+    }
+}

--- a/platforms/macos/Sources/Managers/NamedTunnelManager.swift
+++ b/platforms/macos/Sources/Managers/NamedTunnelManager.swift
@@ -75,8 +75,33 @@ final class NamedTunnelManager {
         discoveryService.isLoggedIn
     }
 
+    /// Local port → public exposures, across currently running tunnels.
+    ///
+    /// Built once and reused, so the per-port-row lookups in the All Ports list
+    /// (each calling `exposures(for:)`) don't each re-scan every tunnel's rules.
+    /// `@Observable` tracks the `tunnels` access, so SwiftUI still recomputes this
+    /// when tunnel state changes.
+    var exposuresByPort: [Int: [PortExposure]] {
+        var result: [Int: [PortExposure]] = [:]
+        for tunnel in tunnels where tunnel.status == .running {
+            for rule in tunnel.ingressRules {
+                guard let localPort = rule.localPort,
+                      let hostname = rule.hostname,
+                      let publicURL = rule.publicURL else { continue }
+                result[localPort, default: []].append(PortExposure(
+                    hostname: hostname,
+                    publicURL: publicURL,
+                    tunnelName: tunnel.name,
+                    tunnelID: tunnel.tunnelID
+                ))
+            }
+        }
+        return result
+    }
+
     /// All public hostnames exposed for a given local port across currently running tunnels.
     /// Returns an empty array if no running tunnel maps to that port.
+    /// For bulk lookups across many ports, prefer reading `exposuresByPort` once.
     func exposures(for localPort: Int) -> [PortExposure] {
         var result: [PortExposure] = []
         for tunnel in tunnels where tunnel.status == .running {
@@ -128,11 +153,18 @@ final class NamedTunnelManager {
             if let existing = existingByID[d.tunnelID] {
                 tunnel = existing
                 tunnel.credentialsPath = d.credentialsPath
-                tunnel.edgeConnections = d.edgeConnections
-                // Only overwrite ingress from config.yml if we haven't picked up a runtime version.
-                if tunnel.ingressSource != .runtimeLog, !d.localIngress.isEmpty {
-                    tunnel.ingressRules = d.localIngress
-                    tunnel.ingressSource = .localConfig
+                // While we're running the tunnel ourselves, the live connection state
+                // comes from log parsing (`activeConnectionCount`). Don't let a background
+                // `tunnel list` refresh clobber `edgeConnections` / ingress out from under
+                // a running or starting tunnel — leave its runtime-derived state intact.
+                let isLocallyActive = existing.status == .running || existing.status == .starting
+                if !isLocallyActive {
+                    tunnel.edgeConnections = d.edgeConnections
+                    // Only overwrite ingress from config.yml if we haven't picked up a runtime version.
+                    if tunnel.ingressSource != .runtimeLog, !d.localIngress.isEmpty {
+                        tunnel.ingressRules = d.localIngress
+                        tunnel.ingressSource = .localConfig
+                    }
                 }
             } else {
                 tunnel = NamedCloudflareTunnel(tunnelID: d.tunnelID, name: d.name, createdAt: d.createdAt)

--- a/platforms/macos/Sources/Managers/TunnelManager.swift
+++ b/platforms/macos/Sources/Managers/TunnelManager.swift
@@ -11,7 +11,7 @@ final class TunnelManager {
     /// Observable state for UI (extracted)
     let state: TunnelState
 
-    /// The cloudflared service actor
+    /// The cloudflared service actor (shared with NamedTunnelManager).
     let cloudflaredService: CloudflaredService
 
     /// Task for cleaning up orphaned tunnels from previous sessions

--- a/platforms/macos/Sources/Models/NamedCloudflareTunnel.swift
+++ b/platforms/macos/Sources/Models/NamedCloudflareTunnel.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+// MARK: - Ingress Rule
+
+/// A single ingress rule from a tunnel's configuration.
+struct CloudflareTunnelIngressRule: Hashable, Sendable {
+    let hostname: String?
+    let path: String?
+    let service: String
+
+    init(hostname: String?, path: String? = nil, service: String) {
+        self.hostname = hostname
+        self.path = path
+        self.service = service
+    }
+
+    /// Port number parsed out of `http://localhost:PORT` style services.
+    var localPort: Int? {
+        guard let url = URL(string: service), let port = url.port else { return nil }
+        return port
+    }
+
+    var publicURL: String? {
+        guard let hostname else { return nil }
+        let normalizedPath: String
+        if let path, !path.isEmpty {
+            normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
+        } else {
+            normalizedPath = ""
+        }
+        return "https://\(hostname)\(normalizedPath)"
+    }
+}
+
+// MARK: - Remote Connection
+
+/// A live edge connection reported by the Cloudflare control plane (from `tunnel list`).
+struct CloudflareTunnelEdgeConnection: Hashable, Sendable {
+    let id: String
+    let coloName: String
+    let originIP: String
+    let openedAt: Date?
+    let isPendingReconnect: Bool
+}
+
+// MARK: - Status
+
+enum NamedTunnelStatus: String, Sendable {
+    case stopped = "Stopped"
+    case starting = "Starting"
+    case running = "Running"
+    case stopping = "Stopping"
+    case error = "Error"
+}
+
+// MARK: - Named Tunnel
+
+/// A persistent (named) Cloudflare tunnel discovered from the local cloudflared config.
+@Observable
+@MainActor
+final class NamedCloudflareTunnel: Identifiable, Sendable {
+    /// Cloudflare tunnel UUID (stable identity).
+    let tunnelID: String
+    let name: String
+    let createdAt: Date?
+
+    /// Path to the credentials JSON in `~/.cloudflared/`, if present.
+    var credentialsPath: String?
+
+    /// Ingress rules parsed from local `config.yml`. May be empty for dashboard-managed tunnels
+    /// until the first runtime config event arrives in the logs.
+    var ingressRules: [CloudflareTunnelIngressRule] = []
+
+    /// Source of the current ingress rules.
+    var ingressSource: IngressSource = .none
+
+    /// Sticky: true if this tunnel is referenced by the local `~/.cloudflared/config.yml`.
+    /// Stays true even after the runtime config replaces `ingressRules`, so we don't
+    /// mistakenly re-classify a locally-owned tunnel as `.managedElsewhere` once it
+    /// connects to the edge and acquires its own connections.
+    var hasLocalConfigMatch: Bool = false
+
+    /// Live edge connections (from `cloudflared tunnel list`).
+    var edgeConnections: [CloudflareTunnelEdgeConnection] = []
+
+    // Runtime state when this app is running the tunnel locally:
+    var runID: UUID?
+    var status: NamedTunnelStatus = .stopped
+    var startedAt: Date?
+    var lastError: String?
+    var metricsPort: Int?
+    var activeConnectionCount: Int = 0
+    var logs: [TunnelLogEntry] = []
+
+    private static let maxLogEntries = 500
+
+    nonisolated var id: String { tunnelID }
+
+    init(tunnelID: String, name: String, createdAt: Date? = nil) {
+        self.tunnelID = tunnelID
+        self.name = name
+        self.createdAt = createdAt
+    }
+
+    func addLogEntry(_ entry: TunnelLogEntry) {
+        logs.append(entry)
+        if logs.count > Self.maxLogEntries {
+            logs.removeFirst(logs.count - Self.maxLogEntries)
+        }
+    }
+
+    func clearLogs() {
+        logs.removeAll()
+    }
+
+    enum IngressSource: String, Sendable {
+        case none
+        case localConfig
+        case runtimeLog
+    }
+
+    // MARK: - Run Safety
+
+    /// Whether it's safe (and useful) to run this tunnel from this machine.
+    ///
+    /// Cloudflare tunnels support multiple connectors per tunnel (HA / load-balancing),
+    /// so running a tunnel that's already up on a VPS technically works — but on a dev
+    /// laptop that's nearly always a footgun: the laptop becomes a second connector and
+    /// edge requests get round-robined between origins that don't share the same backend
+    /// services. We refuse to run those by default.
+    enum RunSafety: Sendable, Equatable {
+        /// Tunnel has local ingress config — safe to run here.
+        case safe
+        /// Tunnel has live edge connections from other machines and no local ingress.
+        /// Running this would create a competing connector; we block the Run action.
+        case managedElsewhere
+        /// No edge connections anywhere and no local ingress — allowed, but the user
+        /// likely needs to configure ingress first or the tunnel will just 404.
+        case noIngress
+    }
+
+    var runSafety: RunSafety {
+        // If we're the ones running it, it's safe by definition.
+        if status == .running || status == .starting { return .safe }
+        // User explicitly wired this tunnel into their local config.yml.
+        if hasLocalConfigMatch { return .safe }
+        // Edge connections from elsewhere → leave it alone.
+        if !edgeConnections.isEmpty { return .managedElsewhere }
+        return .noIngress
+    }
+}
+
+extension NamedCloudflareTunnel: Hashable {
+    nonisolated func hash(into hasher: inout Hasher) {
+        hasher.combine(tunnelID)
+    }
+
+    nonisolated static func == (lhs: NamedCloudflareTunnel, rhs: NamedCloudflareTunnel) -> Bool {
+        lhs.tunnelID == rhs.tunnelID
+    }
+}

--- a/platforms/macos/Sources/Services/CloudflaredDiscoveryService.swift
+++ b/platforms/macos/Sources/Services/CloudflaredDiscoveryService.swift
@@ -116,27 +116,35 @@ actor CloudflaredDiscoveryService {
     // MARK: - Remote List
 
     private func runTunnelList(cloudflaredPath: String) async -> [RemoteTunnel]? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: cloudflaredPath)
-        process.arguments = ["--output", "json", "tunnel", "list"]
+        // `cloudflared tunnel list` is a network call that can take seconds. The
+        // blocking pipe-read + `waitUntilExit()` runs on a detached task so it does
+        // not tie up this actor's executor (and serialize all other discovery work).
+        let outData: Data? = await Task.detached(priority: .utility) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: cloudflaredPath)
+            process.arguments = ["--output", "json", "tunnel", "list"]
 
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
 
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
+            do {
+                try process.run()
+            } catch {
+                return nil
+            }
 
-        // Read output before waiting to avoid pipe deadlock on large outputs.
-        let outData = stdout.fileHandleForReading.readDataToEndOfFile()
-        _ = stderr.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
+            // Read output before waiting to avoid pipe deadlock on large outputs.
+            let data = stdout.fileHandleForReading.readDataToEndOfFile()
+            _ = stderr.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
 
-        guard process.terminationStatus == 0 else { return nil }
+            guard process.terminationStatus == 0 else { return nil }
+            return data
+        }.value
+
+        guard let outData else { return nil }
         return RemoteTunnel.parseList(outData)
     }
 

--- a/platforms/macos/Sources/Services/CloudflaredDiscoveryService.swift
+++ b/platforms/macos/Sources/Services/CloudflaredDiscoveryService.swift
@@ -1,0 +1,307 @@
+import Foundation
+
+// MARK: - Discovery Service
+
+/// Discovers persistent (named) Cloudflare tunnels from local cloudflared state.
+///
+/// Reads three sources:
+///   1. `~/.cloudflared/<UUID>.json` — credentials files (gives us tunnel ID + AccountTag offline)
+///   2. `cloudflared --output json tunnel list` — authoritative tunnel list with live edge connections
+///   3. `~/.cloudflared/config.yml` — local ingress rules (may not exist for dashboard-managed tunnels)
+actor CloudflaredDiscoveryService {
+    /// Default cloudflared config directory.
+    nonisolated var configDirectory: URL {
+        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".cloudflared", isDirectory: true)
+    }
+
+    nonisolated var configFile: URL {
+        configDirectory.appendingPathComponent("config.yml")
+    }
+
+    nonisolated var certFile: URL {
+        configDirectory.appendingPathComponent("cert.pem")
+    }
+
+    /// Whether the user appears to have logged in via `cloudflared tunnel login`.
+    nonisolated var isLoggedIn: Bool {
+        FileManager.default.fileExists(atPath: certFile.path)
+    }
+
+    // MARK: - Public API
+
+    /// Discover all named tunnels visible to the current user.
+    ///
+    /// Strategy:
+    ///   - Always start with credentials files on disk (works offline).
+    ///   - If cloudflared is available, augment with `tunnel list` (adds remote name + connections).
+    ///   - Merge ingress rules from local `config.yml` if any tunnel name matches the `tunnel:` field.
+    func discover(cloudflaredPath: String?) async -> [DiscoveredTunnel] {
+        var byID: [String: DiscoveredTunnel] = [:]
+
+        // 1. Local credentials files
+        for cred in readCredentialsFiles() {
+            byID[cred.tunnelID] = DiscoveredTunnel(
+                tunnelID: cred.tunnelID,
+                name: cred.tunnelID,  // fallback name; overwritten by list below
+                createdAt: nil,
+                credentialsPath: cred.path,
+                edgeConnections: []
+            )
+        }
+
+        // 2. `cloudflared tunnel list` (authoritative when reachable)
+        if let cloudflaredPath = cloudflaredPath,
+           let listed = await runTunnelList(cloudflaredPath: cloudflaredPath) {
+            for remote in listed {
+                if var existing = byID[remote.id] {
+                    existing.name = remote.name
+                    existing.createdAt = remote.createdAt
+                    existing.edgeConnections = remote.connections
+                    byID[remote.id] = existing
+                } else {
+                    byID[remote.id] = DiscoveredTunnel(
+                        tunnelID: remote.id,
+                        name: remote.name,
+                        createdAt: remote.createdAt,
+                        credentialsPath: nil,
+                        edgeConnections: remote.connections
+                    )
+                }
+            }
+        }
+
+        // 3. Local ingress (config.yml). The `tunnel:` field references either name or UUID.
+        if let localConfig = readLocalConfig() {
+            let tunnelRef = localConfig.tunnelRef
+            for key in byID.keys {
+                let t = byID[key]!
+                if t.tunnelID == tunnelRef || t.name == tunnelRef {
+                    var updated = t
+                    updated.localIngress = localConfig.ingress
+                    byID[key] = updated
+                }
+            }
+        }
+
+        return byID.values.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    // MARK: - Credentials Files
+
+    private nonisolated func readCredentialsFiles() -> [LocalCredential] {
+        guard let entries = try? FileManager.default.contentsOfDirectory(at: configDirectory, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        var result: [LocalCredential] = []
+        for url in entries where url.pathExtension == "json" {
+            // Tunnel credentials filename is the UUID itself.
+            let stem = url.deletingPathExtension().lastPathComponent
+            guard isUUID(stem) else { continue }
+            // Sanity-check by reading the file. We accept either {TunnelID: ...} or just trust the filename.
+            if let data = try? Data(contentsOf: url),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                let id = (json["TunnelID"] as? String) ?? stem
+                result.append(LocalCredential(tunnelID: id, path: url.path))
+            } else {
+                result.append(LocalCredential(tunnelID: stem, path: url.path))
+            }
+        }
+        return result
+    }
+
+    private nonisolated func isUUID(_ s: String) -> Bool {
+        UUID(uuidString: s) != nil
+    }
+
+    // MARK: - Remote List
+
+    private func runTunnelList(cloudflaredPath: String) async -> [RemoteTunnel]? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: cloudflaredPath)
+        process.arguments = ["--output", "json", "tunnel", "list"]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        // Read output before waiting to avoid pipe deadlock on large outputs.
+        let outData = stdout.fileHandleForReading.readDataToEndOfFile()
+        _ = stderr.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else { return nil }
+        return RemoteTunnel.parseList(outData)
+    }
+
+    // MARK: - Local Config
+
+    private nonisolated func readLocalConfig() -> LocalConfig? {
+        guard let raw = try? String(contentsOf: configFile, encoding: .utf8) else { return nil }
+        return parseConfigYAML(raw)
+    }
+
+    /// Tiny purpose-built parser for the subset of cloudflared `config.yml` we need.
+    /// We only extract the top-level `tunnel:` value and the `ingress:` list of
+    /// `{hostname, service}` pairs. This avoids pulling in a YAML dependency.
+    nonisolated func parseConfigYAML(_ source: String) -> LocalConfig? {
+        var tunnelRef: String?
+        var rules: [CloudflareTunnelIngressRule] = []
+        var inIngress = false
+        var currentHostname: String?
+        var currentPath: String?
+        var currentService: String?
+
+        func flushRule() {
+            if let service = currentService {
+                rules.append(CloudflareTunnelIngressRule(hostname: currentHostname, path: currentPath, service: service))
+            }
+            currentHostname = nil
+            currentPath = nil
+            currentService = nil
+        }
+
+        for rawLine in source.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            // Strip comments.
+            let withoutComment: String
+            if let hashIdx = line.firstIndex(of: "#") {
+                withoutComment = String(line[..<hashIdx])
+            } else {
+                withoutComment = line
+            }
+            let trimmed = withoutComment.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+
+            // Top-level keys (no leading whitespace).
+            let isTopLevel = !withoutComment.hasPrefix(" ") && !withoutComment.hasPrefix("\t")
+
+            if isTopLevel {
+                // Leaving the ingress section.
+                if inIngress {
+                    flushRule()
+                    inIngress = false
+                }
+                if let value = stripKey("tunnel", from: trimmed) {
+                    tunnelRef = value
+                } else if trimmed.hasPrefix("ingress:") {
+                    inIngress = true
+                }
+                continue
+            }
+
+            guard inIngress else { continue }
+
+            if trimmed.hasPrefix("- ") {
+                // New rule begins; flush the previous.
+                flushRule()
+                let afterDash = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+                applyIngressField(afterDash, hostname: &currentHostname, path: &currentPath, service: &currentService)
+            } else {
+                applyIngressField(trimmed, hostname: &currentHostname, path: &currentPath, service: &currentService)
+            }
+        }
+        if inIngress { flushRule() }
+
+        guard let tunnelRef = tunnelRef else { return nil }
+        return LocalConfig(tunnelRef: tunnelRef, ingress: rules)
+    }
+
+    private nonisolated func applyIngressField(_ s: String, hostname: inout String?, path: inout String?, service: inout String?) {
+        if let value = stripKey("hostname", from: s) {
+            hostname = value
+        } else if let value = stripKey("path", from: s) {
+            path = value
+        } else if let value = stripKey("service", from: s) {
+            service = value
+        }
+    }
+
+    private nonisolated func stripKey(_ key: String, from line: String) -> String? {
+        let prefix = "\(key):"
+        guard line.hasPrefix(prefix) else { return nil }
+        let value = line.dropFirst(prefix.count).trimmingCharacters(in: .whitespaces)
+        return stripQuotes(value)
+    }
+
+    private nonisolated func stripQuotes(_ s: String) -> String {
+        guard s.count >= 2 else { return s }
+        let first = s.first!
+        let last = s.last!
+        if (first == "\"" && last == "\"") || (first == "'" && last == "'") {
+            return String(s.dropFirst().dropLast())
+        }
+        return s
+    }
+}
+
+// MARK: - Aggregated Discovery Result
+
+struct DiscoveredTunnel: Sendable, Hashable {
+    let tunnelID: String
+    var name: String
+    var createdAt: Date?
+    var credentialsPath: String?
+    var edgeConnections: [CloudflareTunnelEdgeConnection]
+    var localIngress: [CloudflareTunnelIngressRule] = []
+}
+
+// MARK: - Internal Helpers
+
+private struct LocalCredential: Sendable {
+    let tunnelID: String
+    let path: String
+}
+
+struct LocalConfig: Sendable {
+    let tunnelRef: String
+    let ingress: [CloudflareTunnelIngressRule]
+}
+
+private struct RemoteTunnel: Sendable {
+    let id: String
+    let name: String
+    let createdAt: Date?
+    let connections: [CloudflareTunnelEdgeConnection]
+
+    static func parseList(_ data: Data) -> [RemoteTunnel]? {
+        // cloudflared may prepend a `--output json` warning line; find the first `[`.
+        guard let firstBracket = data.firstIndex(of: UInt8(ascii: "[")) else { return nil }
+        let jsonData = data.subdata(in: firstBracket..<data.endIndex)
+        guard let arr = try? JSONSerialization.jsonObject(with: jsonData) as? [[String: Any]] else { return nil }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let isoFallback = ISO8601DateFormatter()
+
+        return arr.compactMap { dict -> RemoteTunnel? in
+            guard let id = dict["id"] as? String, let name = dict["name"] as? String else { return nil }
+            let createdAt: Date? = {
+                guard let s = dict["created_at"] as? String else { return nil }
+                return iso.date(from: s) ?? isoFallback.date(from: s)
+            }()
+            let conns = (dict["connections"] as? [[String: Any]] ?? []).compactMap { c -> CloudflareTunnelEdgeConnection? in
+                guard let id = c["id"] as? String, let colo = c["colo_name"] as? String else { return nil }
+                let originIP = (c["origin_ip"] as? String) ?? ""
+                let openedAt: Date? = {
+                    guard let s = c["opened_at"] as? String else { return nil }
+                    return iso.date(from: s) ?? isoFallback.date(from: s)
+                }()
+                let pending = (c["is_pending_reconnect"] as? Bool) ?? false
+                return CloudflareTunnelEdgeConnection(
+                    id: id,
+                    coloName: colo,
+                    originIP: originIP,
+                    openedAt: openedAt,
+                    isPendingReconnect: pending
+                )
+            }
+            return RemoteTunnel(id: id, name: name, createdAt: createdAt, connections: conns)
+        }
+    }
+}

--- a/platforms/macos/Sources/Services/CloudflaredService.swift
+++ b/platforms/macos/Sources/Services/CloudflaredService.swift
@@ -93,6 +93,30 @@ actor CloudflaredService {
         return process
     }
 
+    /// Start `cloudflared tunnel run <name>` for a persistent named tunnel.
+    /// `--metrics 127.0.0.1:0` lets cloudflared pick a free port for its metrics
+    /// endpoint instead of contending with whatever the user already has on :20241.
+    func runNamedTunnel(id: UUID, tunnelName: String) throws -> Process {
+        guard let cloudflaredPath = cloudflaredPath else {
+            throw CloudflaredError.notInstalled
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: cloudflaredPath)
+        process.arguments = ["tunnel", "--metrics", "127.0.0.1:0", "run", tunnelName]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        processes[id] = process
+
+        startReadingOutput(pipe: pipe, id: id)
+
+        return process
+    }
+
     func stopTunnel(id: UUID) async {
         // Cancel output reading task
         outputTasks[id]?.cancel()

--- a/platforms/macos/Sources/Views/CloudflareTunnels/CloudflareTunnelsView.swift
+++ b/platforms/macos/Sources/Views/CloudflareTunnels/CloudflareTunnelsView.swift
@@ -1,57 +1,90 @@
 import SwiftUI
 
+// MARK: - Cloudflare Tunnels View
+
+/// List pane for the Cloudflare Tunnels sidebar item.
+/// Composed of the named (persistent) tunnels list and, when present, a Quick
+/// Tunnels strip below. Detail for the selected tunnel renders in the right
+/// pane via `NamedTunnelDetailView` (wired in `MainWindowView`).
 struct CloudflareTunnelsView: View {
     @Environment(AppState.self) private var appState
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
             header
 
             Divider()
 
-            // Dependency warning banner
             if !appState.tunnelManager.isCloudflaredInstalled {
                 CloudflaredMissingBanner()
                 Divider()
             }
 
-            // Content
-            if appState.tunnelManager.tunnels.isEmpty {
-                emptyState
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                tunnelsList
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    NamedTunnelsSection()
+
+                    if !appState.tunnelManager.tunnels.isEmpty {
+                        quickTunnelsSection
+                    }
+                }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Divider()
 
-            // Status bar
             statusBar
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            appState.namedTunnelManager.startRefreshing()
+        }
+        .onDisappear {
+            appState.namedTunnelManager.stopRefreshing()
+        }
     }
 
     // MARK: - Header
 
     private var header: some View {
-        HStack {
+        HStack(spacing: 8) {
             Text("Cloudflare Tunnels")
                 .font(.headline)
 
             Spacer()
 
-            if appState.tunnelManager.tunnels.count > 0 {
-                Button {
-                    Task {
-                        await appState.tunnelManager.stopAllTunnels()
+            Button {
+                appState.namedTunnelManager.discover(force: true)
+            } label: {
+                if appState.namedTunnelManager.isDiscovering {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            .buttonStyle(.borderless)
+            .help("Refresh tunnel list")
+            .disabled(appState.namedTunnelManager.isDiscovering)
+
+            if appState.namedTunnelManager.runningCount > 0 || appState.tunnelManager.activeTunnelCount > 0 {
+                Menu {
+                    if appState.namedTunnelManager.runningCount > 0 {
+                        Button(role: .destructive) {
+                            Task { await appState.namedTunnelManager.stopAll() }
+                        } label: { Label("Stop All My Tunnels", systemImage: "stop.fill") }
+                    }
+                    if appState.tunnelManager.activeTunnelCount > 0 {
+                        Button(role: .destructive) {
+                            Task { await appState.tunnelManager.stopAllTunnels() }
+                        } label: { Label("Stop All Quick Tunnels", systemImage: "stop.fill") }
                     }
                 } label: {
-                    Label("Stop All", systemImage: "stop.fill")
+                    Image(systemName: "ellipsis.circle")
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("More actions")
             }
         }
         .padding(.horizontal, 12)
@@ -59,38 +92,22 @@ struct CloudflareTunnelsView: View {
         .background(Color(nsColor: .windowBackgroundColor))
     }
 
-    // MARK: - Empty State
-
-    private var emptyState: some View {
-        ContentUnavailableView {
-            Label("No Active Tunnels", systemImage: "cloud")
-        } description: {
-            Text("Share a port via tunnel from the port list to create a public URL")
-        }
-    }
-
-    // MARK: - Tunnels List
-
-    private var tunnelsList: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(appState.tunnelManager.tunnels) { tunnel in
-                    CloudflareTunnelRow(tunnel: tunnel)
-                    Divider()
-                }
-            }
-        }
+    private func statusSummary(running: Int, quick: Int) -> String {
+        var parts: [String] = []
+        if running > 0 { parts.append("\(running) running") }
+        if quick > 0 { parts.append("\(quick) quick") }
+        return parts.joined(separator: " · ")
     }
 
     // MARK: - Status Bar
 
     private var statusBar: some View {
-        HStack {
-            if appState.tunnelManager.activeTunnelCount > 0 {
-                Circle()
-                    .fill(Color.green)
-                    .frame(width: 8, height: 8)
-                Text("\(appState.tunnelManager.activeTunnelCount) active tunnel(s)")
+        let running = appState.namedTunnelManager.runningCount
+        let quick = appState.tunnelManager.activeTunnelCount
+        return HStack(spacing: 12) {
+            if running > 0 || quick > 0 {
+                Circle().fill(Color.green).frame(width: 8, height: 8)
+                Text(statusSummary(running: running, quick: quick))
             } else {
                 Text("No active tunnels")
             }
@@ -109,9 +126,33 @@ struct CloudflareTunnelsView: View {
         .padding(.vertical, 8)
         .background(Color(nsColor: .windowBackgroundColor))
     }
+
+    // MARK: - Quick Tunnels Section
+
+    @ViewBuilder
+    private var quickTunnelsSection: some View {
+        HStack(spacing: 6) {
+            Text("Quick Tunnels")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+            Text("\(appState.tunnelManager.tunnels.count)")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.tertiary)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 10)
+        .padding(.bottom, 4)
+
+        ForEach(appState.tunnelManager.tunnels) { tunnel in
+            CloudflareTunnelRow(tunnel: tunnel)
+            Divider().padding(.leading, 32)
+        }
+    }
 }
 
-// MARK: - Tunnel Row
+// MARK: - Quick Tunnel Row
 
 struct CloudflareTunnelRow: View {
     let tunnel: CloudflareTunnelState
@@ -188,48 +229,33 @@ struct CloudflareTunnelRow: View {
             }
         }
         .background(isHovered ? Color.primary.opacity(0.05) : Color.clear)
-        .onHover { hovering in
-            isHovered = hovering
-        }
+        .onHover { isHovered = $0 }
         .contextMenu {
             if tunnel.status == .active, let url = tunnel.tunnelURL {
                 Button {
                     ClipboardService.copy(url)
-                } label: {
-                    Label("Copy URL", systemImage: "doc.on.doc")
-                }
-
+                } label: { Label("Copy URL", systemImage: "doc.on.doc") }
                 Button {
                     if let tunnelURL = URL(string: url) {
                         NSWorkspace.shared.open(tunnelURL)
                     }
-                } label: {
-                    Label("Open in Browser", systemImage: "globe")
-                }
-
+                } label: { Label("Open in Browser", systemImage: "globe") }
                 Divider()
             }
-
             Button {
                 showLogs.toggle()
-            } label: {
-                Label(showLogs ? "Hide Logs" : "Show Logs", systemImage: "doc.text")
-            }
-
+            } label: { Label(showLogs ? "Hide Logs" : "Show Logs", systemImage: "doc.text") }
             Divider()
-
             Button(role: .destructive) {
                 appState.tunnelManager.stopTunnel(id: tunnel.id)
-            } label: {
-                Label("Stop Tunnel", systemImage: "stop.fill")
-            }
+            } label: { Label("Stop Tunnel", systemImage: "stop.fill") }
         }
     }
 
     private var statusIndicator: some View {
         Circle()
             .fill(statusColor)
-            .frame(width: 10, height: 10)
+            .frame(width: 8, height: 8)
     }
 
     private var statusColor: Color {

--- a/platforms/macos/Sources/Views/CloudflareTunnels/NamedTunnelDetailView.swift
+++ b/platforms/macos/Sources/Views/CloudflareTunnels/NamedTunnelDetailView.swift
@@ -1,0 +1,455 @@
+import SwiftUI
+
+/// Right-pane detail view for a selected named Cloudflare tunnel.
+/// Shows full ingress mapping, edge connections, metadata, and live logs.
+/// Mirrors the structure of `PortDetailView` so the two panes feel consistent.
+struct NamedTunnelDetailView: View {
+    let tunnel: NamedCloudflareTunnel
+    @Environment(AppState.self) private var appState
+    @State private var showLogs = true
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+
+                Divider()
+
+                metaSection
+
+                if !tunnel.ingressRules.isEmpty {
+                    Divider()
+                    ingressSection
+                }
+
+                if !tunnel.edgeConnections.isEmpty {
+                    Divider()
+                    edgeConnectionsSection
+                }
+
+                if tunnel.runSafety == .managedElsewhere {
+                    Divider()
+                    managedElsewhereExplanation
+                }
+
+                Divider()
+
+                logsSection
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                ZStack {
+                    Circle()
+                        .fill(statusColor.opacity(0.2))
+                        .frame(width: 48, height: 48)
+                    Image(systemName: "cloud.fill")
+                        .font(.title2)
+                        .foregroundStyle(statusColor)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(tunnel.name)
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                        .lineLimit(1)
+
+                    Text(tunnel.status.rawValue)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+
+            statusBadges
+            actionRow
+        }
+    }
+
+    private var statusColor: Color {
+        switch tunnel.status {
+        case .running: .green
+        case .starting, .stopping: .yellow
+        case .error: .red
+        case .stopped:
+            tunnel.runSafety == .managedElsewhere ? .orange : .secondary
+        }
+    }
+
+    private var statusBadges: some View {
+        HStack(spacing: 8) {
+            badge(text: tunnel.status.rawValue, tint: statusColor)
+
+            if tunnel.status == .running {
+                badge(
+                    text: "\(tunnel.activeConnectionCount) connections",
+                    icon: "link",
+                    tint: .green
+                )
+            }
+
+            switch tunnel.runSafety {
+            case .safe:
+                if tunnel.hasLocalConfigMatch {
+                    badge(text: "Local config", icon: "doc.text", tint: .blue)
+                }
+            case .managedElsewhere:
+                badge(text: "Managed elsewhere", icon: "lock.fill", tint: .orange)
+            case .noIngress:
+                badge(text: "No ingress", icon: "exclamationmark.triangle", tint: .yellow)
+            }
+
+            Spacer()
+        }
+    }
+
+    private func badge(text: String, icon: String? = nil, tint: Color) -> some View {
+        HStack(spacing: 4) {
+            if let icon { Image(systemName: icon) }
+            Text(text)
+        }
+        .font(.caption)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(tint.opacity(0.2))
+        .foregroundStyle(tint)
+        .clipShape(Capsule())
+    }
+
+    @ViewBuilder
+    private var actionRow: some View {
+        HStack(spacing: 8) {
+            switch tunnel.status {
+            case .stopped, .error:
+                if tunnel.runSafety == .managedElsewhere {
+                    Button {
+                        appState.namedTunnelManager.run(tunnel, allowManagedElsewhere: true)
+                    } label: {
+                        Label("Run Anyway", systemImage: "play.fill")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .tint(.orange)
+                    .disabled(!appState.tunnelManager.isCloudflaredInstalled)
+                    .help("Add this Mac as another connector for the tunnel")
+                } else {
+                    Button {
+                        appState.namedTunnelManager.run(tunnel)
+                    } label: {
+                        Label("Run Tunnel", systemImage: "play.fill")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(!appState.tunnelManager.isCloudflaredInstalled)
+                }
+            case .starting, .stopping:
+                Button {} label: {
+                    HStack { ProgressView().controlSize(.small); Text(tunnel.status.rawValue) }
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .disabled(true)
+            case .running:
+                Button {
+                    appState.namedTunnelManager.stop(tunnel)
+                } label: {
+                    Label("Stop Tunnel", systemImage: "stop.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .tint(.red)
+            }
+        }
+    }
+
+    // MARK: - Meta
+
+    private var metaSection: some View {
+        LazyVGrid(columns: [
+            GridItem(.flexible(), alignment: .topLeading),
+            GridItem(.flexible(), alignment: .topLeading)
+        ], spacing: 16) {
+            metaItem(label: "Tunnel ID", value: tunnel.tunnelID, monospaced: true)
+            metaItem(label: "Ingress Source", value: ingressSourceLabel)
+            if let created = tunnel.createdAt {
+                metaItem(label: "Created", value: created.formatted(date: .abbreviated, time: .shortened))
+            }
+            if let metricsPort = tunnel.metricsPort {
+                metaItem(label: "Metrics", value: "127.0.0.1:\(metricsPort)", monospaced: true)
+            }
+            if let started = tunnel.startedAt, tunnel.status == .running {
+                metaItem(label: "Started", value: started.formatted(.relative(presentation: .named)))
+            }
+            if let credentials = tunnel.credentialsPath {
+                metaItem(label: "Credentials", value: (credentials as NSString).abbreviatingWithTildeInPath, monospaced: true)
+            }
+        }
+    }
+
+    private var ingressSourceLabel: String {
+        switch tunnel.ingressSource {
+        case .none: return "—"
+        case .localConfig: return "~/.cloudflared/config.yml"
+        case .runtimeLog: return "Cloudflare dashboard"
+        }
+    }
+
+    private func metaItem(label: String, value: String, monospaced: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(monospaced ? .system(.caption, design: .monospaced) : .callout)
+                .textSelection(.enabled)
+                .lineLimit(2)
+                .truncationMode(.middle)
+        }
+    }
+
+    // MARK: - Ingress
+
+    private var ingressSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Ingress Rules")
+                .font(.headline)
+
+            VStack(spacing: 4) {
+                ForEach(Array(tunnel.ingressRules.enumerated()), id: \.offset) { _, rule in
+                    IngressRuleDetailRow(rule: rule)
+                }
+            }
+        }
+    }
+
+    // MARK: - Edge Connections
+
+    private var edgeConnectionsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Edge Connections")
+                    .font(.headline)
+                Text("\(tunnel.edgeConnections.count)")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color.secondary.opacity(0.15)))
+                Spacer()
+            }
+
+            VStack(spacing: 4) {
+                ForEach(tunnel.edgeConnections, id: \.id) { conn in
+                    HStack(spacing: 10) {
+                        Circle()
+                            .fill(conn.isPendingReconnect ? Color.yellow : Color.green)
+                            .frame(width: 6, height: 6)
+                        Text(conn.coloName)
+                            .font(.system(.callout, design: .monospaced).weight(.semibold))
+                            .frame(minWidth: 60, alignment: .leading)
+                        Text(conn.originIP)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        if let opened = conn.openedAt {
+                            Text(opened, style: .relative)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+            }
+        }
+    }
+
+    // MARK: - Managed Elsewhere Explanation
+
+    private var managedElsewhereExplanation: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "lock.fill")
+                .foregroundStyle(.orange)
+                .font(.title3)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("This tunnel is managed by another origin")
+                    .font(.subheadline.weight(.semibold))
+                Text("It has active edge connections from other machines and no local ingress configuration. Running it here adds this Mac as another connector, which can split traffic between origins. Use Run Anyway only if that is intentional.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.orange.opacity(0.08)))
+    }
+
+    // MARK: - Logs
+
+    private var logsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Logs")
+                    .font(.headline)
+                Spacer()
+                if !tunnel.logs.isEmpty {
+                    Text("\(tunnel.logs.count) entries")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    Button {
+                        tunnel.clearLogs()
+                    } label: {
+                        Label("Clear", systemImage: "trash")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+                Button {
+                    showLogs.toggle()
+                } label: {
+                    Image(systemName: showLogs ? "chevron.down" : "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if showLogs {
+                if tunnel.logs.isEmpty {
+                    Text(tunnel.status == .running ? "Waiting for output…" : "No logs yet. Run the tunnel to see live output.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .background(Color(nsColor: .textBackgroundColor))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                } else {
+                    NamedTunnelLogView(tunnel: tunnel)
+                        .frame(height: 240)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Ingress Row (detail-pane variant)
+
+private struct IngressRuleDetailRow: View {
+    let rule: CloudflareTunnelIngressRule
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if let publicURL = rule.publicURL {
+                Button {
+                    if let url = URL(string: publicURL) {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(publicURL)
+                            .font(.system(.callout, design: .monospaced))
+                            .foregroundStyle(.blue)
+                        Image(systemName: "arrow.up.forward.app")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .buttonStyle(.plain)
+            } else {
+                Text("(fallback)")
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+            }
+
+            Image(systemName: "arrow.right")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+
+            Text(rule.service)
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer()
+
+            if let publicURL = rule.publicURL {
+                Button {
+                    ClipboardService.copy(publicURL)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .help("Copy URL")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+// MARK: - Log View
+
+struct NamedTunnelLogView: View {
+    let tunnel: NamedCloudflareTunnel
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 1) {
+                    ForEach(tunnel.logs) { entry in
+                        HStack(alignment: .top, spacing: 6) {
+                            Text(entry.timestamp, style: .time)
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                            Text(entry.message)
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundStyle(color(for: entry.level))
+                                .textSelection(.enabled)
+                            Spacer(minLength: 0)
+                        }
+                        .padding(.horizontal, 8)
+                        .id(entry.id)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .background(Color.black.opacity(0.85))
+            .onChange(of: tunnel.logs.count) { _, _ in
+                if let last = tunnel.logs.last {
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private func color(for level: TunnelLogEntry.LogLevel) -> Color {
+        switch level {
+        case .info: .white.opacity(0.85)
+        case .warning: .orange
+        case .error: .red
+        case .request: .cyan
+        }
+    }
+}

--- a/platforms/macos/Sources/Views/CloudflareTunnels/NamedTunnelsSection.swift
+++ b/platforms/macos/Sources/Views/CloudflareTunnels/NamedTunnelsSection.swift
@@ -1,0 +1,340 @@
+import SwiftUI
+
+// MARK: - Section
+
+/// Compact list of persistent (named) Cloudflare tunnels.
+/// Selecting a row routes detail to `NamedTunnelDetailView` in the right pane,
+/// matching how the All Ports view uses the detail column.
+///
+/// Rows are grouped by actionability — **Running** / **Available** /
+/// **Managed Elsewhere** — using simple section labels (no card backgrounds)
+/// so the look stays consistent with the rest of the app.
+struct NamedTunnelsSection: View {
+    @Environment(AppState.self) private var appState
+    @State private var managedElsewhereExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if !appState.namedTunnelManager.isLoggedIn && !appState.namedTunnelManager.tunnels.isEmpty {
+                loginWarning
+            }
+
+            if appState.namedTunnelManager.tunnels.isEmpty {
+                if appState.namedTunnelManager.isDiscovering {
+                    discoveringRow
+                } else if !appState.namedTunnelManager.isLoggedIn {
+                    placeholderMessage(
+                        icon: "person.crop.circle.badge.exclamationmark",
+                        title: "Not logged in to Cloudflare",
+                        detail: "Run `cloudflared tunnel login` in Terminal to list account tunnels. Local tunnel credentials and config are still supported when present."
+                    )
+                } else {
+                    placeholderMessage(
+                        icon: "cloud",
+                        title: "No tunnels yet",
+                        detail: "Create one with `cloudflared tunnel create <name>` or via the Cloudflare dashboard."
+                    )
+                }
+            } else {
+                if !running.isEmpty {
+                    sectionLabel("Running", count: running.count)
+                    ForEach(running) { tunnel in
+                        NamedTunnelRow(tunnel: tunnel)
+                        Divider().padding(.leading, 32)
+                    }
+                }
+                if !available.isEmpty {
+                    sectionLabel("Available", count: available.count)
+                    ForEach(available) { tunnel in
+                        NamedTunnelRow(tunnel: tunnel)
+                        Divider().padding(.leading, 32)
+                    }
+                }
+                if !managedElsewhere.isEmpty {
+                    managedElsewhereGroup
+                }
+            }
+        }
+    }
+
+    // MARK: - Groupings
+
+    private var running: [NamedCloudflareTunnel] {
+        appState.namedTunnelManager.tunnels.filter {
+            $0.status == .running || $0.status == .starting
+        }
+    }
+
+    private var available: [NamedCloudflareTunnel] {
+        appState.namedTunnelManager.tunnels.filter {
+            ($0.status == .stopped || $0.status == .error) && $0.runSafety != .managedElsewhere
+        }
+    }
+
+    private var managedElsewhere: [NamedCloudflareTunnel] {
+        appState.namedTunnelManager.tunnels.filter {
+            $0.status != .running && $0.status != .starting && $0.runSafety == .managedElsewhere
+        }
+    }
+
+    // MARK: - Subviews
+
+    private func sectionLabel(_ title: String, count: Int) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+            Text("\(count)")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.tertiary)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 10)
+        .padding(.bottom, 4)
+    }
+
+    private var managedElsewhereGroup: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    managedElsewhereExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(managedElsewhereExpanded ? 90 : 0))
+                    Text("Managed Elsewhere")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .textCase(.uppercase)
+                    Text("\(managedElsewhere.count)")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+                .padding(.bottom, 4)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if managedElsewhereExpanded {
+                ForEach(managedElsewhere) { tunnel in
+                    NamedTunnelRow(tunnel: tunnel)
+                    Divider().padding(.leading, 32)
+                }
+            }
+        }
+    }
+
+    private func placeholderMessage(icon: String, title: String, detail: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title).font(.subheadline)
+                Text(detail).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(20)
+    }
+
+    private var loginWarning: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "person.crop.circle.badge.exclamationmark")
+                .font(.title3)
+                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Cloudflare account login not found")
+                    .font(.caption.weight(.semibold))
+                Text("Showing locally configured tunnels only. Run `cloudflared tunnel login` to discover all account tunnels.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color.orange.opacity(0.08))
+    }
+
+    private var discoveringRow: some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.small)
+            Text("Discovering tunnels…")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(20)
+    }
+}
+
+// MARK: - Named Tunnel Row
+
+/// Compact list row for a named tunnel. Matches the visual weight of
+/// `PortListRow`: status dot + name + subtitle + trailing actions. No card
+/// background; selection state is communicated via background tint.
+struct NamedTunnelRow: View {
+    let tunnel: NamedCloudflareTunnel
+    @Environment(AppState.self) private var appState
+    @State private var isHovered = false
+
+    private var isSelected: Bool {
+        appState.selectedNamedTunnelID == tunnel.tunnelID
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            statusDot
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(tunnel.name)
+                    .font(.body)
+                    .lineLimit(1)
+
+                subtitle
+            }
+
+            Spacer(minLength: 8)
+
+            if tunnel.status == .running {
+                Text("\(tunnel.activeConnectionCount) conn")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+
+            trailingControl
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(rowBackground)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            appState.selectedNamedTunnelID = tunnel.tunnelID
+        }
+        .onHover { isHovered = $0 }
+        .contextMenu { contextMenu }
+    }
+
+    // MARK: - Subviews
+
+    private var statusDot: some View {
+        Circle()
+            .fill(statusColor)
+            .frame(width: 8, height: 8)
+    }
+
+    private var statusColor: Color {
+        switch tunnel.status {
+        case .running: .green
+        case .starting, .stopping: .yellow
+        case .error: .red
+        case .stopped:
+            tunnel.runSafety == .managedElsewhere ? .orange : .secondary
+        }
+    }
+
+    @ViewBuilder
+    private var subtitle: some View {
+        let routes = tunnel.ingressRules.compactMap { $0.publicURL }
+        if tunnel.status == .error, let error = tunnel.lastError {
+            Text(error).font(.caption).foregroundStyle(.red).lineLimit(1)
+        } else if tunnel.status == .starting {
+            Text("Starting…").font(.caption).foregroundStyle(.secondary)
+        } else if tunnel.runSafety == .managedElsewhere {
+            HStack(spacing: 3) {
+                Image(systemName: "lock.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                Text("Managed elsewhere")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } else if let first = routes.first {
+            HStack(spacing: 4) {
+                Text(first)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                if routes.count > 1 {
+                    Text("+\(routes.count - 1)")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        } else {
+            Text("No ingress configured").font(.caption).foregroundStyle(.tertiary)
+        }
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        switch tunnel.status {
+        case .stopped, .error:
+            if tunnel.runSafety != .managedElsewhere {
+                Button {
+                    appState.namedTunnelManager.run(tunnel)
+                } label: {
+                    Label("Run", systemImage: "play.fill")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(!appState.tunnelManager.isCloudflaredInstalled)
+                .help("Run this tunnel")
+            }
+        case .starting, .stopping:
+            ProgressView().controlSize(.small)
+        case .running:
+            Button {
+                appState.namedTunnelManager.stop(tunnel)
+            } label: {
+                Label("Stop", systemImage: "stop.fill")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .tint(.red)
+            .help("Stop this tunnel")
+        }
+    }
+
+    @ViewBuilder
+    private var contextMenu: some View {
+        if tunnel.status == .running {
+            Button(role: .destructive) {
+                appState.namedTunnelManager.stop(tunnel)
+            } label: { Label("Stop Tunnel", systemImage: "stop.fill") }
+        } else if tunnel.runSafety == .managedElsewhere {
+            Button {
+                appState.namedTunnelManager.run(tunnel, allowManagedElsewhere: true)
+            } label: { Label("Run Anyway", systemImage: "play.fill") }
+        } else if tunnel.runSafety != .managedElsewhere {
+            Button {
+                appState.namedTunnelManager.run(tunnel)
+            } label: { Label("Run Tunnel", systemImage: "play.fill") }
+        }
+        Divider()
+        Button {
+            ClipboardService.copy(tunnel.tunnelID)
+        } label: { Label("Copy Tunnel ID", systemImage: "doc.on.doc") }
+    }
+
+    private var rowBackground: some View {
+        Group {
+            if isSelected {
+                Color.accentColor.opacity(0.2)
+            } else if isHovered {
+                Color.primary.opacity(0.05)
+            } else {
+                Color.clear
+            }
+        }
+    }
+}

--- a/platforms/macos/Sources/Views/Components/PortRow/PortRowView.swift
+++ b/platforms/macos/Sources/Views/Components/PortRow/PortRowView.swift
@@ -78,9 +78,14 @@ struct PortRowView: View {
             PortStatusIndicator(isActive: port.isActive)
                 .padding(.trailing, 8)
 
-            // Port
-            PortNumberDisplay(port: port.port, isActive: port.isActive)
-                .frame(width: 70, alignment: .leading)
+            // Port + exposure indicator
+            HStack(spacing: 4) {
+                PortNumberDisplay(port: port.port, isActive: port.isActive)
+                if port.isActive {
+                    TunnelExposureBadge(port: port.port)
+                }
+            }
+            .frame(width: 90, alignment: .leading)
 
             // Process
             PortProcessInfo(
@@ -253,8 +258,9 @@ struct PortRowView: View {
                         .font(.caption2)
                         .foregroundStyle(.blue)
                 }
+                TunnelExposureBadge(port: port.port, compact: true)
             }
-            .frame(width: 100, alignment: .leading)
+            .frame(width: 110, alignment: .leading)
             .opacity(isKilling ? 0.5 : 1)
 
             // Process name + label

--- a/platforms/macos/Sources/Views/Components/PortRow/TunnelExposureBadge.swift
+++ b/platforms/macos/Sources/Views/Components/PortRow/TunnelExposureBadge.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Small globe icon next to a port number, signalling that the port is exposed
+/// via a running named Cloudflare tunnel. Full hostname list lives in
+/// `PortDetailView` — keeping the list compact.
+///
+/// Tooltip and context menu surface the hostnames inline for quick access.
+struct TunnelExposureBadge: View {
+    let port: Int
+    var compact: Bool = false
+
+    @Environment(AppState.self) private var appState
+
+    private var exposures: [PortExposure] {
+        appState.namedTunnelManager.exposures(for: port)
+    }
+
+    var body: some View {
+        if exposures.isEmpty {
+            EmptyView()
+        } else {
+            badge
+        }
+    }
+
+    private var badge: some View {
+        Button {
+            if let first = exposures.first {
+                open(first.publicURL)
+            }
+        } label: {
+            Image(systemName: "globe")
+                .font(compact ? .caption2 : .caption)
+                .foregroundStyle(.orange)
+        }
+        .buttonStyle(.plain)
+        .help(tooltip)
+        .contextMenu {
+            ForEach(exposures, id: \.publicURL) { exposure in
+                Button {
+                    open(exposure.publicURL)
+                } label: { Label(exposure.publicURL, systemImage: "globe") }
+            }
+            Divider()
+            ForEach(exposures, id: \.publicURL) { exposure in
+                Button {
+                    ClipboardService.copy(exposure.publicURL)
+                } label: { Label("Copy \(exposure.publicURL)", systemImage: "doc.on.doc") }
+            }
+        }
+    }
+
+    private var tooltip: String {
+        if exposures.count == 1, let one = exposures.first {
+            return "Exposed via \(one.tunnelName): \(one.publicURL)"
+        }
+        let list = exposures.map { $0.publicURL }.joined(separator: ", ")
+        return "\(exposures.count) routes: \(list)"
+    }
+
+    private func open(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/platforms/macos/Sources/Views/MainWindowView.swift
+++ b/platforms/macos/Sources/Views/MainWindowView.swift
@@ -97,10 +97,20 @@ struct MainWindowView: View {
 
     @ViewBuilder
     private var detailView: some View {
-        if appState.selectedSidebarItem == .settings || appState.selectedSidebarItem == .sponsors || appState.selectedSidebarItem == .cloudflareTunnels {
+        if appState.selectedSidebarItem == .settings || appState.selectedSidebarItem == .sponsors {
             EmptyView()
         } else if appState.selectedSidebarItem == .kubernetesPortForward {
             ConnectionLogPanel(connection: appState.selectedPortForwardConnection)
+        } else if appState.selectedSidebarItem == .cloudflareTunnels {
+            if let tunnel = appState.selectedNamedTunnel {
+                NamedTunnelDetailView(tunnel: tunnel)
+            } else {
+                ContentUnavailableView {
+                    Label("No Tunnel Selected", systemImage: "cloud")
+                } description: {
+                    Text("Select a tunnel from the list to view details")
+                }
+            }
         } else if let selectedPort = appState.selectedPort {
             PortDetailView(port: selectedPort)
         } else {

--- a/platforms/macos/Sources/Views/MenuBar/MenuBarNamedTunnelRow.swift
+++ b/platforms/macos/Sources/Views/MenuBar/MenuBarNamedTunnelRow.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+/// Compact menu-bar row for a persistent (named) Cloudflare tunnel.
+/// Provides Run/Stop controls and shows a one-line ingress summary.
+struct MenuBarNamedTunnelRow: View {
+    let tunnel: NamedCloudflareTunnel
+    @Bindable var state: AppState
+    @State private var isHovered = false
+
+    private var statusColor: Color {
+        switch tunnel.status {
+        case .stopped: .secondary.opacity(0.3)
+        case .starting: .orange
+        case .running: .green
+        case .stopping: .orange
+        case .error: .red
+        }
+    }
+
+    private var primaryRoute: String? {
+        tunnel.ingressRules.compactMap { $0.publicURL }.first
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle().fill(statusColor).frame(width: 6, height: 6)
+                .shadow(color: tunnel.status == .running ? .green.opacity(0.5) : .clear, radius: 3)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(tunnel.name)
+                    .font(.callout)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+
+                subtitle
+            }
+
+            Spacer()
+
+            if tunnel.status == .running {
+                Text("\(tunnel.activeConnectionCount)")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.green)
+                    .help("\(tunnel.activeConnectionCount) active edge connections")
+            }
+
+            trailingControls
+        }
+        .padding(.horizontal, 12).padding(.vertical, 6)
+        .background(isHovered ? Color.primary.opacity(0.05) : Color.clear)
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+        .contextMenu { contextMenu }
+    }
+
+    @ViewBuilder
+    private var subtitle: some View {
+        if tunnel.runSafety == .managedElsewhere {
+            Text("Managed elsewhere")
+                .font(.caption2)
+                .foregroundStyle(.orange)
+        } else if tunnel.status == .starting {
+            Text("Starting…").font(.caption2).foregroundStyle(.secondary)
+        } else if tunnel.status == .running {
+            Text(tunnel.status.rawValue)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        } else if tunnel.ingressRules.isEmpty {
+            Text("No ingress").font(.caption2).foregroundStyle(.tertiary)
+        } else {
+            Text("\(tunnel.ingressRules.compactMap { $0.publicURL }.count) route(s)")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    @ViewBuilder
+    private var trailingControls: some View {
+        switch tunnel.status {
+        case .stopped, .error:
+            if tunnel.runSafety != .managedElsewhere {
+                Button {
+                    state.namedTunnelManager.run(tunnel)
+                } label: {
+                    Image(systemName: "play.fill").font(.caption)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.green)
+                .opacity(isHovered ? 1 : 0.7)
+                .help("Run tunnel")
+            }
+        case .starting, .stopping:
+            ProgressView().scaleEffect(0.5).frame(width: 14, height: 14)
+        case .running:
+            Button {
+                state.namedTunnelManager.stop(tunnel)
+            } label: {
+                Image(systemName: "stop.fill").font(.caption).foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+            .opacity(isHovered ? 1 : 0.7)
+            .help("Stop tunnel")
+        }
+    }
+
+    @ViewBuilder
+    private var contextMenu: some View {
+        if tunnel.status == .running {
+            Button(role: .destructive) {
+                state.namedTunnelManager.stop(tunnel)
+            } label: { Label("Stop Tunnel", systemImage: "stop.fill") }
+        } else if tunnel.runSafety != .managedElsewhere {
+            Button {
+                state.namedTunnelManager.run(tunnel)
+            } label: { Label("Run Tunnel", systemImage: "play.fill") }
+        }
+        if let route = primaryRoute {
+            Divider()
+            Button {
+                if let url = URL(string: route) {
+                    NSWorkspace.shared.open(url)
+                }
+            } label: { Label("Open \(route)", systemImage: "globe") }
+        }
+    }
+}

--- a/platforms/macos/Sources/Views/MenuBar/MenuBarPortList.swift
+++ b/platforms/macos/Sources/Views/MenuBar/MenuBarPortList.swift
@@ -18,19 +18,35 @@ struct MenuBarPortList: View {
     @Binding var confirmingKillPort: String?
     @Bindable var state: AppState
 
+    /// Named tunnels worth showing in the menu bar: currently running + any with
+    /// local ingress (the ones the user likely wants quick access to). Filters out
+    /// dashboard-managed prod tunnels to avoid clutter.
+    private var menuBarNamedTunnels: [NamedCloudflareTunnel] {
+        state.namedTunnelManager.tunnels.filter { tunnel in
+            tunnel.status == .running ||
+            tunnel.status == .starting ||
+            tunnel.runSafety == .safe
+        }
+    }
+
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                // Active Cloudflare Tunnels
-                if !state.tunnelManager.tunnels.isEmpty {
-                    sectionHeader("Cloudflare Tunnels", icon: "cloud.fill", color: .orange)
+                // Local ports first — port killing is the app's primary job, so this
+                // is where the user's eye should land. Networking sections live below.
+                if filteredPorts.isEmpty && filteredPortForwardConnections.isEmpty && state.tunnelManager.tunnels.isEmpty && menuBarNamedTunnels.isEmpty {
+                    emptyState
+                } else if !filteredPorts.isEmpty {
+                    sectionHeader("Local Ports", icon: "network", color: .green)
 
-                    ForEach(state.tunnelManager.tunnels) { tunnel in
-                        MenuBarTunnelRow(tunnel: tunnel, state: state)
+                    if useTreeView {
+                        treeView
+                    } else {
+                        listView
                     }
                 }
 
-                // Port Forward connections grouped by namespace
+                // K8s Port Forward connections grouped by namespace
                 if !filteredPortForwardConnections.isEmpty {
                     sectionHeader("K8s Port Forward", icon: "point.3.connected.trianglepath.dotted", color: .blue)
 
@@ -42,16 +58,22 @@ struct MenuBarPortList: View {
                     }
                 }
 
-                // Normal ports
-                if filteredPorts.isEmpty && filteredPortForwardConnections.isEmpty && state.tunnelManager.tunnels.isEmpty {
-                    emptyState
-                } else if !filteredPorts.isEmpty {
-                    sectionHeader("Local Ports", icon: "network", color: .green)
+                // Active Quick Tunnels (port-derived)
+                if !state.tunnelManager.tunnels.isEmpty {
+                    sectionHeader("Quick Tunnels", icon: "bolt.fill", color: .yellow)
 
-                    if useTreeView {
-                        treeView
-                    } else {
-                        listView
+                    ForEach(state.tunnelManager.tunnels) { tunnel in
+                        MenuBarTunnelRow(tunnel: tunnel, state: state)
+                    }
+                }
+
+                // Named (persistent) Cloudflare Tunnels — at the bottom: a tunnel
+                // runner is the least-frequent quick action versus inspecting/killing ports.
+                if !menuBarNamedTunnels.isEmpty {
+                    sectionHeader("My Tunnels", icon: "cloud.fill", color: .orange)
+
+                    ForEach(menuBarNamedTunnels) { tunnel in
+                        MenuBarNamedTunnelRow(tunnel: tunnel, state: state)
                     }
                 }
             }

--- a/platforms/macos/Sources/Views/MenuBar/MenuBarView.swift
+++ b/platforms/macos/Sources/Views/MenuBar/MenuBarView.swift
@@ -140,7 +140,10 @@ struct MenuBarView: View {
             )
         }
         .frame(width: 340)
-        .onAppear { updateCachedData() }
+        .onAppear {
+            updateCachedData()
+            state.namedTunnelManager.discoverIfNeeded()
+        }
         .onChange(of: state.ports) { _, _ in updateCachedData() }
         .onChange(of: searchText) { _, _ in updateCachedData() }
         .onChange(of: hideSystemProcesses) { _, _ in updateCachedData() }

--- a/platforms/macos/Sources/Views/PortDetailView.swift
+++ b/platforms/macos/Sources/Views/PortDetailView.swift
@@ -16,6 +16,12 @@ struct PortDetailView: View {
                 // Details Grid
                 detailsGrid
 
+                // Tunnel exposures (only shown when ≥1 named tunnel maps to this port)
+                if !exposures.isEmpty {
+                    Divider()
+                    exposuresSection
+                }
+
                 Divider()
 
                 // Command
@@ -141,6 +147,63 @@ struct PortDetailView: View {
             DetailRow(title: "User", value: port.user)
             DetailRow(title: "File Descriptor", value: port.fd)
             DetailRow(title: "Type", value: port.processType.rawValue)
+        }
+    }
+
+    private var exposures: [PortExposure] {
+        guard port.isActive else { return [] }
+        return appState.namedTunnelManager.exposures(for: port.port)
+    }
+
+    private var exposuresSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "globe").foregroundStyle(.orange)
+                Text("Exposed via Cloudflare Tunnel")
+                    .font(.headline)
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(exposures, id: \.publicURL) { exposure in
+                    HStack(spacing: 8) {
+                        Button {
+                            if let url = URL(string: exposure.publicURL) {
+                                NSWorkspace.shared.open(url)
+                            }
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text(exposure.publicURL)
+                                    .font(.system(.body, design: .monospaced))
+                                    .foregroundStyle(.blue)
+                                Image(systemName: "arrow.up.forward.app")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .buttonStyle(.plain)
+
+                        Spacer()
+
+                        Text(exposure.tunnelName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        Button {
+                            ClipboardService.copy(exposure.publicURL)
+                        } label: {
+                            Image(systemName: "doc.on.doc")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Copy URL")
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+            }
         }
     }
 

--- a/platforms/macos/Sources/Views/SidebarView.swift
+++ b/platforms/macos/Sources/Views/SidebarView.swift
@@ -168,14 +168,15 @@ struct SidebarView: View {
                 Text("Cloudflare Tunnels")
                 Spacer()
 
-                // Status indicator
-                if appState.tunnelManager.activeTunnelCount > 0 {
+                let activeCount = appState.tunnelManager.activeTunnelCount + appState.namedTunnelManager.runningCount
+                if activeCount > 0 {
                     Circle()
                         .fill(Color.green)
                         .frame(width: 8, height: 8)
                 }
 
-                Text("\(appState.tunnelManager.tunnels.count)")
+                let totalCount = appState.tunnelManager.tunnels.count + appState.namedTunnelManager.tunnels.count
+                Text("\(totalCount)")
                     .foregroundStyle(.secondary)
                     .font(.caption)
                     .frame(minWidth: 20)

--- a/platforms/macos/Tests/CloudflaredDiscoveryServiceTests.swift
+++ b/platforms/macos/Tests/CloudflaredDiscoveryServiceTests.swift
@@ -58,4 +58,39 @@ struct CloudflaredDiscoveryServiceTests {
 
         #expect(rule.publicURL == "https://api.example.com")
     }
+
+    @Test("Handles comment-only lines, blank lines and tab indentation")
+    func handlesCommentsBlankLinesAndTabs() {
+        let service = CloudflaredDiscoveryService()
+        // Mixes a full-line comment, blank lines, and tab-indented ingress entries.
+        let config = "# top-level comment\n"
+            + "tunnel: dev-tunnel\n"
+            + "\n"
+            + "# ingress below\n"
+            + "ingress:\n"
+            + "\t- hostname: api.example.com\n"
+            + "\t  service: http://localhost:3000 # trailing comment\n"
+            + "\t- service: http_status:404\n"
+
+        let parsed = service.parseConfigYAML(config)
+
+        #expect(parsed?.tunnelRef == "dev-tunnel")
+        #expect(parsed?.ingress.count == 2)
+        #expect(parsed?.ingress[0].hostname == "api.example.com")
+        #expect(parsed?.ingress[0].service == "http://localhost:3000")
+        #expect(parsed?.ingress[1].hostname == nil)
+        #expect(parsed?.ingress[1].service == "http_status:404")
+    }
+
+    @Test("Returns nil when no tunnel reference is present")
+    func returnsNilWithoutTunnelRef() {
+        let service = CloudflaredDiscoveryService()
+        let config = """
+        ingress:
+          - hostname: api.example.com
+            service: http://localhost:3000
+        """
+
+        #expect(service.parseConfigYAML(config) == nil)
+    }
 }

--- a/platforms/macos/Tests/CloudflaredDiscoveryServiceTests.swift
+++ b/platforms/macos/Tests/CloudflaredDiscoveryServiceTests.swift
@@ -1,0 +1,61 @@
+import Testing
+@testable import PortKiller
+
+struct CloudflaredDiscoveryServiceTests {
+    @Test("Parses local cloudflared config ingress rules")
+    func parsesLocalConfigIngressRules() {
+        let service = CloudflaredDiscoveryService()
+        let config = """
+        tunnel: dev-tunnel
+        credentials-file: /Users/test/.cloudflared/dev-tunnel.json
+
+        ingress:
+          - hostname: api.example.com
+            path: /v1/*
+            service: http://localhost:3000
+          - hostname: app.example.com
+            service: http://127.0.0.1:5173
+          - service: http_status:404
+        """
+
+        let parsed = service.parseConfigYAML(config)
+
+        #expect(parsed?.tunnelRef == "dev-tunnel")
+        #expect(parsed?.ingress.count == 3)
+        #expect(parsed?.ingress[0].hostname == "api.example.com")
+        #expect(parsed?.ingress[0].path == "/v1/*")
+        #expect(parsed?.ingress[0].service == "http://localhost:3000")
+        #expect(parsed?.ingress[0].localPort == 3000)
+        #expect(parsed?.ingress[0].publicURL == "https://api.example.com/v1/*")
+        #expect(parsed?.ingress[1].localPort == 5173)
+        #expect(parsed?.ingress[2].hostname == nil)
+        #expect(parsed?.ingress[2].publicURL == nil)
+    }
+
+    @Test("Parses quoted tunnel references and strips comments")
+    func parsesQuotedValuesAndComments() {
+        let service = CloudflaredDiscoveryService()
+        let config = """
+        tunnel: "7c48df31-7c1f-4f87-a17d-a1a7f0622b9d" # account tunnel
+        ingress:
+          - hostname: 'www.example.com'
+            path: "admin"
+            service: "http://localhost:8080"
+        """
+
+        let parsed = service.parseConfigYAML(config)
+
+        #expect(parsed?.tunnelRef == "7c48df31-7c1f-4f87-a17d-a1a7f0622b9d")
+        #expect(parsed?.ingress.first?.hostname == "www.example.com")
+        #expect(parsed?.ingress.first?.path == "admin")
+        #expect(parsed?.ingress.first?.service == "http://localhost:8080")
+        #expect(parsed?.ingress.first?.publicURL == "https://www.example.com/admin")
+    }
+
+    @Test("Ingress public URL omits an empty path")
+    func publicURLOmitsEmptyPath() {
+        let rule = CloudflareTunnelIngressRule(hostname: "api.example.com", service: "http://localhost:3000")
+
+        #expect(rule.publicURL == "https://api.example.com")
+    }
+}


### PR DESCRIPTION
PortKiller currently only supports Quick Tunnels (the throwaway `*.trycloudflare.com` URLs). This adds the other kind - named tunnels you create with `cloudflared tunnel create` and normally run with `cloudflared tunnel run <name>` from a terminal.

After this PR:
- Tunnels from `~/.cloudflared/` and `cloudflared tunnel list` show up under Cloudflare Tunnels, grouped Running / Available / Managed Elsewhere.
- Run / Stop buttons in the list, detail pane on the right with ingress, edge connections, and live logs.
- Active ports in the All Ports view get a small globe badge linking to the public URL when a running tunnel routes to them.
- "My Tunnels" section at the bottom of the menu bar dropdown.

One thing worth flagging: cloudflared supports multiple connectors per tunnel, so if a tunnel already has edge connections from another machine and no local ingress in `config.yml`, the Run button is hidden by default, running it from your laptop too would just create a competing connector. There's a "Run Anyway" in the detail view if you really want it.

Discovery is lazy - nothing runs `cloudflared tunnel list` until you open the Cloudflare Tunnels pane or the menu bar dropdown.

Closes #55.