### PR TITLE
fix: Use latest homebrew syntax for macos "depends on"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,7 +377,7 @@ jobs:
             desc "Menu bar app to find and kill processes running on open ports"
             homepage "https://github.com/productdevbook/port-killer"
 
-            depends_on macos: ">= :sequoia"
+            depends_on macos: :sequoia
 
             app "PortKiller.app"
 


### PR DESCRIPTION
Hey!

Kept getting this error:
```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sequoia` instead.
Please report this issue to the productdevbook/homebrew-tap tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/productdevbook/homebrew-tap/Casks/portkiller.rb:11
```

I think latest [version of brew deprecated this string check ](https://github.com/Homebrew/homebrew-cask/pull/268102)(https://brew.sh/2026/06/11/homebrew-6.0.0/) 